### PR TITLE
Update Output.cshtml to new Registry Object format.

### DIFF
--- a/Cli/Output/Output.cshtml
+++ b/Cli/Output/Output.cshtml
@@ -1,6 +1,6 @@
 ﻿@using RazorLight
 @using AttackSurfaceAnalyzer.ObjectTypes
-
+@using Newtonsoft.Json;
 
 <!doctype html>
 <html class="no-js" lang="">
@@ -456,8 +456,8 @@
                                         <tr>
                                             <th></th>
                                             <th>Key</th>
-                                            <th>Value (if applicable)</th>
-                                            <th>Contents (if a value)</th>
+                                            <th>Subkeys (if applicable)</th>
+                                            <th>Values (if a value)</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -466,8 +466,8 @@
                                             <tr>
                                                 <td>Deleted</td>
                                                 <td>@i.Base.Key</td>
-                                                <td>@i.Base.Value</td>
-                                                <td>@i.Base.Contents</td>
+                                                <td>@JsonConvert.SerializeObject(i.Base.Subkeys)</td>
+                                                <td>@JsonConvert.SerializeObject(i.Base.Values)</td>
                                             </tr>
                                         }
                                         @foreach (RegistryResult i in Model["registry_add"])
@@ -475,8 +475,8 @@
                                             <tr>
                                                 <td>New</td>
                                                 <td>@i.Compare.Key</td>
-                                                <td>@i.Compare.Value</td>
-                                                <td>@i.Compare.Contents</td>
+                                                <td>@JsonConvert.SerializeObject(i.Compare.Subkeys)</td>
+                                                <td>@JsonConvert.SerializeObject(i.Compare.Values)</td>
                                             </tr>
                                         }
                                         @foreach (RegistryResult i in Model["registry_modify"])
@@ -484,14 +484,14 @@
                                             <tr>
                                                 <td>Modified:Before</td>
                                                 <td>@i.Base.Key</td>
-                                                <td>@i.Base.Value</td>
-                                                <td>@i.Base.Contents</td>
+                                                <td>JsonConvert.SerializeObject(@i.Base.Subkeys)</td>
+                                                <td>JsonConvert.SerializeObject(@i.Base.Values)</td>
                                             </tr>
                                             <tr>
                                                 <td>Modified:After</td>
                                                 <td>@i.Compare.Key</td>
-                                                <td>@i.Compare.Value</td>
-                                                <td>@i.Compare.Contents</td>
+                                                <td>JsonConvert.SerializeObject(@i.Compare.Subkeys)</td>
+                                                <td>JsonConvert.SerializeObject(@i.Compare.Values)</td>
                                             </tr>
                                         }
                                     </tbody>
@@ -565,8 +565,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
 
-    <script type="text/javascript">
-        $(document).ready(function () {
+    <script type="text/javascript">$(document).ready(function () {
             $('a[data-internal-link="replace"]').on('click', function (e) {
                 var href = $(e.target).attr('href');  // show this href
                 var $t = $('div' + href);               // this element
@@ -574,8 +573,7 @@
                     $('main').html($t.html());
                 }
             });
-        })
-    </script>
+        })</script>
 
 </body>
 

--- a/Cli/Program.cs
+++ b/Cli/Program.cs
@@ -325,24 +325,25 @@ namespace AttackSurfaceAnalyzer.Cli
 #else
             Logger.Setup(false, opts.Verbose);
 #endif
+            Logger.Instance.Debug("Entering RunExportCollectCommand");
 
             DatabaseManager.SqliteFilename = opts.DatabaseFilename;
             DatabaseManager.Commit();
 
             bool RunComparisons = true;
+            //string SQL_CHECK_IF_COMPARISON_PREVIOUSLY_COMPLETED = "select * from results where base_run_id=@base_run_id and compare_run_id=@compare_run_id";
 
-            string SQL_CHECK_IF_COMPARISON_PREVIOUSLY_COMPLETED = "select * from results where base_run_id=@base_run_id and compare_run_id=@compare_run_id";
-
-            var cmd = new SqliteCommand(SQL_CHECK_IF_COMPARISON_PREVIOUSLY_COMPLETED, DatabaseManager.Connection);
-            cmd.Parameters.AddWithValue("@base_run_id", opts.FirstRunId);
-            cmd.Parameters.AddWithValue("@compare_run_id", opts.SecondRunId);
-            using (var reader = cmd.ExecuteReader())
-            {
-                while (reader.Read())
-                {
-                    RunComparisons = false;
-                }
-            }
+            //var cmd = new SqliteCommand(SQL_CHECK_IF_COMPARISON_PREVIOUSLY_COMPLETED, DatabaseManager.Connection);
+            //cmd.Parameters.AddWithValue("@base_run_id", opts.FirstRunId);
+            //cmd.Parameters.AddWithValue("@compare_run_id", opts.SecondRunId);
+            //using (var reader = cmd.ExecuteReader())
+            //{
+            //    while (reader.Read())
+            //    {
+            //        RunComparisons = false;
+            //    }
+            //}
+            Logger.Instance.Debug("Halfway RunExportCollectCommand");
 
             CompareCommandOptions options = new CompareCommandOptions();
             options.DatabaseFilename = opts.DatabaseFilename;
@@ -353,6 +354,7 @@ namespace AttackSurfaceAnalyzer.Cli
             {
                 CompareRuns(options);
             }
+            Logger.Instance.Debug("Done comparing RunExportCollectCommand");
 
             WriteScanJson(0, opts.FirstRunId, opts.SecondRunId, true, opts.OutputPath);
 
@@ -364,6 +366,8 @@ namespace AttackSurfaceAnalyzer.Cli
         {
             string GET_COMPARISON_RESULTS = "select * from compared where base_run_id=@base_run_id and compare_run_id=@compare_run_id and data_type=@data_type order by base_row_key;";
             string GET_SERIALIZED_RESULTS = "select serialized from @table_name where row_key = @row_key and run_id = @run_id";
+
+            Logger.Instance.Debug("Starting WriteScanJson");
 
             List<RESULT_TYPE> ToExport = new List<RESULT_TYPE> { (RESULT_TYPE)ResultType };
             Dictionary<RESULT_TYPE, int> actualExported = new Dictionary<RESULT_TYPE, int>();

--- a/Cli/Program.cs
+++ b/Cli/Program.cs
@@ -27,7 +27,7 @@ namespace AttackSurfaceAnalyzer.Cli
     [Verb("compare", HelpText = "Compare ASA executions and output a .html summary")]
     public class CompareCommandOptions
     {
-        [Option(Required = false, HelpText = "Name of output database (default: asa.sqlite)", Default = "asa.sqlite")]
+        [Option(Required = false, HelpText = "Name of output database", Default = "asa.sqlite")]
         public string DatabaseFilename { get; set; }
 
         [Option(Required = true, HelpText = "First run (pre-install) identifier")]
@@ -36,7 +36,7 @@ namespace AttackSurfaceAnalyzer.Cli
         [Option(Required = true, HelpText = "Second run (post-install) identifier")]
         public string SecondRunId { get; set; }
 
-        [Option(Required = false, HelpText = "Base name of output file (default: output)", Default = "output")]
+        [Option(Required = false, HelpText = "Base name of output file", Default = "output")]
         public string OutputBaseFilename { get; set; }
 
         [Option(Default = false, HelpText = "Increase logging verbosity")]
@@ -46,7 +46,7 @@ namespace AttackSurfaceAnalyzer.Cli
     [Verb("export-collect", HelpText = "Compare ASA executions and output a .json report")]
     public class ExportCollectCommandOptions
     {
-        [Option(Required = false, HelpText = "Name of output database (default: asa.sqlite)", Default = "asa.sqlite")]
+        [Option(Required = false, HelpText = "Name of output database", Default = "asa.sqlite")]
         public string DatabaseFilename { get; set; }
 
         [Option(Required = true, HelpText = "First run (pre-install) identifier")]
@@ -55,7 +55,7 @@ namespace AttackSurfaceAnalyzer.Cli
         [Option(Required = true, HelpText = "Second run (post-install) identifier")]
         public string SecondRunId { get; set; }
 
-        [Option(Required = false, HelpText = "Directory to output to (default: .)", Default = ".")]
+        [Option(Required = false, HelpText = "Directory to output to", Default = ".")]
         public string OutputPath { get; set; }
 
         [Option(Default = false, HelpText = "Increase logging verbosity")]
@@ -65,13 +65,13 @@ namespace AttackSurfaceAnalyzer.Cli
     [Verb("export-monitor", HelpText = "Output a .json report for a monitor run")]
     public class ExportMonitorCommandOptions
     {
-        [Option(Required = false, HelpText = "Name of output database (default: asa.sqlite)", Default = "asa.sqlite")]
+        [Option(Required = false, HelpText = "Name of output database", Default = "asa.sqlite")]
         public string DatabaseFilename { get; set; }
 
         [Option(Required = true, HelpText = "Monitor run identifier")]
         public string RunId { get; set; }
 
-        [Option(Required = false, HelpText = "Directory to output to (default: .)", Default = ".")]
+        [Option(Required = false, HelpText = "Directory to output to", Default = ".")]
         public string OutputPath { get; set; }
 
         [Option(Default = false, HelpText = "Increase logging verbosity")]
@@ -84,7 +84,7 @@ namespace AttackSurfaceAnalyzer.Cli
         [Option(Required = true, HelpText = "Identifies which run this is (used during comparison)")]
         public string RunId { get; set; }
 
-        [Option(Required = false, HelpText = "Name of output database (default: asa.sqlite)", Default = "asa.sqlite")]
+        [Option(Required = false, HelpText = "Name of output database", Default = "asa.sqlite")]
         public string DatabaseFilename { get; set; }
 
         [Option('c', "certificates", Required = false, HelpText = "Enable the certificate store collector")]
@@ -129,7 +129,7 @@ namespace AttackSurfaceAnalyzer.Cli
         [Option(Required = true, HelpText = "Identifies which run this is. Monitor output can be combined with collect output, but doesn't need to be compared.")]
         public string RunId { get; set; }
 
-        [Option(Required = false, HelpText = "Name of output database (default: asa.sqlite)", Default = "asa.sqlite")]
+        [Option(Required = false, HelpText = "Name of output database", Default = "asa.sqlite")]
         public string DatabaseFilename { get; set; }
 
         [Option('f', "file-system", Required = false, HelpText = "Enable the file system monitor. Unless -d is specified will monitor the entire file system.")]
@@ -800,6 +800,8 @@ namespace AttackSurfaceAnalyzer.Cli
 
             comparators = new List<BaseCompare>();
 
+            Logger.Instance.Debug("Getting result types");
+
             var cmd = new SqliteCommand(SQL_GET_RESULT_TYPES, DatabaseManager.Connection);
             cmd.Parameters.AddWithValue("@base_run_id", opts.FirstRunId);
             cmd.Parameters.AddWithValue("@compare_run_id", opts.SecondRunId);
@@ -875,7 +877,8 @@ namespace AttackSurfaceAnalyzer.Cli
                     }
                 }
             }
-            
+            Logger.Instance.Debug("Inserting run into results table as running");
+
             cmd = new SqliteCommand(INSERT_RUN_INTO_RESULT_TABLE_SQL, DatabaseManager.Connection, DatabaseManager.Transaction);
             cmd.Parameters.AddWithValue("@base_run_id", opts.FirstRunId);
             cmd.Parameters.AddWithValue("@compare_run_id", opts.SecondRunId);
@@ -884,6 +887,7 @@ namespace AttackSurfaceAnalyzer.Cli
 
             foreach (var c in comparators)
             {
+                Logger.Instance.Info("Starting {0}", c.GetType());
                 if (!c.TryCompare(opts.FirstRunId, opts.SecondRunId))
                 {
                     Logger.Instance.Warn("Error when comparing {0}", c.GetType().FullName);
@@ -1183,6 +1187,7 @@ namespace AttackSurfaceAnalyzer.Cli
 #endif
             DatabaseManager.SqliteFilename = opts.DatabaseFilename;
 
+            Logger.Instance.Debug("Starting CompareRuns");
             var results = CompareRuns(opts);
 
             var engine = new RazorLightEngineBuilder()

--- a/Gui/wwwroot/js/Analyze.js
+++ b/Gui/wwwroot/js/Analyze.js
@@ -385,11 +385,11 @@ function InsertIntoRegistryTable(result) {
     }));
     tmp.append($('<td/>', {
         scope: "col",
-        html: appendObj.Value
+        html: JSON.stringify(appendObj.Subkeys)
     }));
     tmp.append($('<td/>', {
         scope: "col",
-        html: appendObj.Contents
+        html: JSON.stringify(appendObj.Values)
     }));
     $('#RegistryResultsTableBody').append(tmp);
     tmp = $('<tr/>');

--- a/Lib/Collectors/Registry/RegistryCollector.cs
+++ b/Lib/Collectors/Registry/RegistryCollector.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Security.AccessControl;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using AttackSurfaceAnalyzer.ObjectTypes;
 using AttackSurfaceAnalyzer.Utils;
@@ -127,9 +128,10 @@ namespace AttackSurfaceAnalyzer.Collectors.Registry
                 (hive =>
                 {
                     Logger.Instance.Debug("Starting " + hive.ToString());
-                    if (Filter.IsFiltered(Filter.RuntimeString(), "Scan", "Registry", "Hive", "Exclude", hive.ToString()))
+                    if (Filter.IsFiltered(Filter.RuntimeString(), "Scan", "Registry", "Hive", "Exclude", hive.ToString(), out Regex Capturer))
                     {
-                        Logger.Instance.Debug("Excluding {0} due to filter.", hive.ToString());
+                        Logger.Instance.Info("Hi mom");
+                        Logger.Instance.Info("Excluding hive '{0}' due to filter '{1}'.", hive.ToString(), Capturer.ToString());
                     }
                     else
                     {

--- a/Lib/Utils/DatabaseManager.cs
+++ b/Lib/Utils/DatabaseManager.cs
@@ -20,7 +20,6 @@ namespace AttackSurfaceAnalyzer.Utils
         private static readonly string SQL_CREATE_REGISTRY_COLLECTION = "create table if not exists registry (run_id text, row_key text, key text, value text, subkeys text, permissions text, serialized text)";
         private static readonly string SQL_CREATE_CERTIFICATES_COLLECTION = "create table if not exists certificates (run_id text, row_key text, pkcs12 text, store_location text, store_name text, hash text, hash_plus_store text, cert text, cn text, serialized text)";
 
-        private static readonly string SQL_CREATE_COMPARE_RESULT_TABLE = "create table if not exists compared (base_run_id text, compare_run_id test, change_type int, base_row_key text, compare_row_key text, data_type int)";
 
         private static readonly string SQL_CREATE_ANALYZED_TABLE = "create table if not exists results (base_run_id text, compare_run_id text, status int)";
 
@@ -29,16 +28,20 @@ namespace AttackSurfaceAnalyzer.Utils
         private static readonly string SQL_CREATE_REGISTRY_ROW_KEY_INDEX = "create index if not exists registry_row_key_index on registry(row_key)";
         private static readonly string SQL_CREATE_REGISTRY_RUN_ID_INDEX = "create index if not exists registry_run_id_index on registry(run_id)";
 
+        private static readonly string SQL_CREATE_COMPARE_RESULT_TABLE = "create table if not exists compared (base_run_id text, compare_run_id test, change_type int, base_row_key text, compare_row_key text, data_type int)";
+        private static readonly string SQL_CREATE_RESULT_CHANGE_TYPE_INDEX = "create index if not exists i_compared_change_type_index on compared(change_type)";
+        private static readonly string SQL_CREATE_RESULT_BASE_RUN_ID_INDEX = "create index if not exists i_compared_base_run_id on compared(base_run_id)";
+        private static readonly string SQL_CREATE_RESULT_COMPARE_RUN_ID_INDEX = "create index if not exists i_compared_compare_run_id on compared(compare_run_id)";
+        private static readonly string SQL_CREATE_RESULT_BASE_ROW_KEY_INDEX = "create index if not exists i_compared_base_row_key on compared(base_row_key)";
+        private static readonly string SQL_CREATE_RESULT_DATA_TYPE_INDEX = "create index if not exists i_compared_data_type_index on compared(data_type)";
 
-        private static readonly string SQL_CREATE_RESULT_CHANGE_TYPE_INDEX = "create index if not exists change_type_index on compared(change_type)";
-        private static readonly string SQL_CREATE_RESULT_BASE_RUN_ID_INDEX = "create index if not exists base_run_index on compared(base_run_id)";
-        private static readonly string SQL_CREATE_RESULT_COMPARE_RUN_ID_INDEX = "create index if not exists compare_run_index on compared(compare_run_id)";
 
         private static readonly string SQL_CREATE_PERSISTED_SETTINGS = "create table if not exists persisted_settings (setting text, value text, unique(setting))";
         private static readonly string SQL_CREATE_DEFAULT_SETTINGS = "insert or ignore into persisted_settings (setting, value) values ('telemetry_opt_out','false')";
 
 
         private static readonly string SQL_GET_RESULT_TYPES_SINGLE = "select * from runs where run_id = @run_id";
+
         private static readonly string SQL_TRUNCATE_CERTIFICATES = "delete from certificates where run_id=@run_id";
         private static readonly string SQL_TRUNCATE_FILES = "delete from file_system where run_id=@run_id";
         private static readonly string SQL_TRUNCATE_USERS = "delete from user_account where run_id = @run_id";
@@ -122,6 +125,12 @@ namespace AttackSurfaceAnalyzer.Utils
                 cmd = new SqliteCommand(SQL_CREATE_RESULT_COMPARE_RUN_ID_INDEX, DatabaseManager.Connection, DatabaseManager.Transaction);
                 cmd.ExecuteNonQuery();
 
+                cmd = new SqliteCommand(SQL_CREATE_RESULT_BASE_ROW_KEY_INDEX, DatabaseManager.Connection, DatabaseManager.Transaction);
+                cmd.ExecuteNonQuery();
+
+                cmd = new SqliteCommand(SQL_CREATE_RESULT_DATA_TYPE_INDEX, DatabaseManager.Connection, DatabaseManager.Transaction);
+                cmd.ExecuteNonQuery();
+                
                 DatabaseManager.Transaction.Commit();
                 _transaction = null;
                 Logger.Instance.Debug("Done with database setup");

--- a/Lib/Utils/Filter.cs
+++ b/Lib/Utils/Filter.cs
@@ -28,8 +28,12 @@ namespace AttackSurfaceAnalyzer.Utils
             }
             return "Unknown";
         }
-        public static bool IsFiltered(string Platform, string ScanType, string ItemType, string Property, string FilterType, string Target)
+
+        public static bool IsFiltered(string Platform, string ScanType, string ItemType, string Property, string FilterType, string Target) => IsFiltered(Platform, ScanType, ItemType, Property, FilterType, Target, out Regex dummy);
+
+        public static bool IsFiltered(string Platform, string ScanType, string ItemType, string Property, string FilterType, string Target, out Regex regex)
         {
+            regex = null;
             if (config == null)
             {
                 return false;
@@ -51,7 +55,8 @@ namespace AttackSurfaceAnalyzer.Utils
 
                         if (rgx.IsMatch(Target))
                         {
-                            Logger.Instance.Trace("{0} caught {1}", rgx, Target);
+                            regex = rgx;
+                            Logger.Instance.Debug("{0} caught {1}", rgx, Target);
                             return true;
                         }
                     }

--- a/Lib/Utils/Logger.cs
+++ b/Lib/Utils/Logger.cs
@@ -45,7 +45,7 @@ namespace AttackSurfaceAnalyzer.Utils
                 config.AddRuleForOneLevel(LogLevel.Error, consoleTarget);
                 config.AddRuleForOneLevel(LogLevel.Fatal, consoleTarget);
             }
-            if (debug)
+            if (debug || verbose)
             {
                 config.AddRuleForAllLevels(fileTarget);
             }


### PR DESCRIPTION
Fixes regression from #43.  When the registry object format was rewritten, I neglected to update the Cli HTML output, which references attributes directly.