### PR TITLE
Show RunId on collect status page

### DIFF
--- a/Cli/Program.cs
+++ b/Cli/Program.cs
@@ -1325,5 +1325,16 @@ namespace AttackSurfaceAnalyzer.Cli
                 }
             }
         }
+
+        public static string GetLatestRunId()
+        {
+            if (collectors.Count > 0)
+            {
+                return collectors[0].runId;
+            }
+            return "No run id";
+        }
     }
+
+
 }

--- a/Gui/Controllers/HomeController.cs
+++ b/Gui/Controllers/HomeController.cs
@@ -273,15 +273,26 @@ namespace AttackSurfaceAnalyzer.Gui.Controllers
         public ActionResult GetCollectors()
         {
             Dictionary<string, RUN_STATUS> dict = new Dictionary<string, RUN_STATUS>();
+            string RunId = "Error obtaining run Id";
+
+            //TODO: Improve this to not have to change this variable on every loop, without having to call GetCollectors twice.
             foreach (BaseCollector c in AttackSurfaceAnalyzerCLI.GetCollectors())
             {
                 var fullString = c.GetType().ToString();
                 var splits = fullString.Split('.');
                 dict.Add(splits[splits.Count()-1], c.IsRunning());
+                RunId = c.runId;
             }
-
+            Dictionary<string, object> output = new Dictionary<string, object>();
+            output.Add("RunId", RunId);
+            output.Add("Runs", dict);
             //@TODO: Also return the RunId
-            return Json(JsonConvert.SerializeObject(dict));
+            return Json(JsonConvert.SerializeObject(output));
+        }
+
+        public ActionResult GetLatestRunId()
+        {
+            
         }
 
         public ActionResult GetMonitorStatus()

--- a/Gui/Controllers/HomeController.cs
+++ b/Gui/Controllers/HomeController.cs
@@ -273,7 +273,7 @@ namespace AttackSurfaceAnalyzer.Gui.Controllers
         public ActionResult GetCollectors()
         {
             Dictionary<string, RUN_STATUS> dict = new Dictionary<string, RUN_STATUS>();
-            string RunId = "Error obtaining run Id";
+            string RunId = AttackSurfaceAnalyzerCLI.GetLatestRunId();
 
             //TODO: Improve this to not have to change this variable on every loop, without having to call GetCollectors twice.
             foreach (BaseCollector c in AttackSurfaceAnalyzerCLI.GetCollectors())
@@ -281,7 +281,6 @@ namespace AttackSurfaceAnalyzer.Gui.Controllers
                 var fullString = c.GetType().ToString();
                 var splits = fullString.Split('.');
                 dict.Add(splits[splits.Count()-1], c.IsRunning());
-                RunId = c.runId;
             }
             Dictionary<string, object> output = new Dictionary<string, object>();
             output.Add("RunId", RunId);
@@ -292,7 +291,7 @@ namespace AttackSurfaceAnalyzer.Gui.Controllers
 
         public ActionResult GetLatestRunId()
         {
-            
+            return Json(AttackSurfaceAnalyzerCLI.GetLatestRunId());
         }
 
         public ActionResult GetMonitorStatus()

--- a/Gui/Views/Home/Collect.cshtml
+++ b/Gui/Views/Home/Collect.cshtml
@@ -164,6 +164,11 @@
     @* Status section *@
 
     <div class="col-6" id="RunStatus">
+        <div class="row font-weight-bold">
+            <div class="col">
+                Run Status
+            </div>
+        </div>
         <div class="container d-flex h-100">
             <div class="row">
                 <div class="col" id="ScanLiner"></div>

--- a/Gui/wwwroot/js/Collect.js
+++ b/Gui/wwwroot/js/Collect.js
@@ -156,12 +156,17 @@ function GetMonitorStatus() {
 function GetCollectors() {
     $.getJSON('GetCollectors', function (result) {
         var data = JSON.parse(result);
+        var rundata = data.Runs;
         var keepChecking = false;
         var anyCollectors = false;
         var icon, midword;
         $('#ScanStatus').empty();
 
-        $.each(data, function (key, value) {
+        if (Object.keys(rundata).length > 0) {
+            $('#ScanStatus').append($('<div/>', { html: "<i>Status report for " + data.RunId + ".</i>" }));
+        }
+
+        $.each(rundata, function (key, value) {
             anyCollectors = true;
             if (value === RUN_STATUS.RUNNING) {
                 keepChecking = true;

--- a/Lib/Collectors/BaseCollector.cs
+++ b/Lib/Collectors/BaseCollector.cs
@@ -11,7 +11,7 @@ namespace AttackSurfaceAnalyzer.Collectors
 {
     public abstract class BaseCollector : PlatformRunnable
     {
-        protected string runId = null;
+        public string runId = null;
 
         private RUN_STATUS _running = RUN_STATUS.NOT_STARTED;
 


### PR DESCRIPTION
Adds an extra feedback item letting users know what run the status on the collect page applies to.

Fixes #92 