### PR TITLE
Add Warning Message

### DIFF
--- a/Cli/Program.cs
+++ b/Cli/Program.cs
@@ -218,7 +218,7 @@ namespace AttackSurfaceAnalyzer.Cli
                     (MonitorCommandOptions opts) => RunMonitorCommand(opts),
                     (ExportCollectCommandOptions opts) => RunExportCollectCommand(opts),
                     (ExportMonitorCommandOptions opts) => RunExportMonitorCommand(opts),
-                    (ConfigCommandOptions opts) => SetupConfig(opts),
+                    (ConfigCommandOptions opts) => RunConfigCommand(opts),
                     errs => 1
                 );
             
@@ -226,7 +226,7 @@ namespace AttackSurfaceAnalyzer.Cli
             Log.CloseAndFlush();
         }
 
-        private static int SetupConfig(ConfigCommandOptions opts)
+        private static int RunConfigCommand(ConfigCommandOptions opts)
         {
             DatabaseManager.SqliteFilename = opts.DatabaseFilename;
 
@@ -982,9 +982,9 @@ namespace AttackSurfaceAnalyzer.Cli
                         FileSystemMonitor newMon = new FileSystemMonitor(opts.RunId, dir, opts.InterrogateChanges);
                         monitors.Add(newMon);
                     }
-                    catch (ArgumentException e)
+                    catch (ArgumentException)
                     {
-                        Log.Information("{0} is an invalid path.",dir);
+                        Log.Warning("{0} is an invalid path.",dir);
                         return ERRORS.INVALID_PATH;
                     }
                 }

--- a/Lib/Utils/DatabaseManager.cs
+++ b/Lib/Utils/DatabaseManager.cs
@@ -279,6 +279,11 @@ namespace AttackSurfaceAnalyzer.Utils
                 cmd.Parameters.AddWithValue("@run_id", runid);
                 using (var reader = cmd.ExecuteReader())
                 {
+                    if (!reader.HasRows)
+                    {
+                        Log.Warning("That Run ID wasn't found in the database");
+                        return;
+                    }
                     while (reader.Read())
                     {
                         using (var inner_cmd = new SqliteCommand(SQL_TRUNCATE_RUN, DatabaseManager.Connection, DatabaseManager.Transaction))


### PR DESCRIPTION
Now gives the user an informational warning message if they try to delete a run that doesn't exist.

Fixes #98 