### PR TITLE
Add extra context for telemetry opt out

### DIFF
--- a/Cli/Program.cs
+++ b/Cli/Program.cs
@@ -178,7 +178,7 @@ namespace AttackSurfaceAnalyzer.Cli
         [Option("reset-database", Required = false, HelpText = "Delete the output database")]
         public bool ResetDatabase { get; set; }
 
-        [Option("telemetry-opt-out", Required = false, HelpText = "Change your telemetry opt out setting")]
+        [Option("telemetry-opt-out", Required = false, HelpText = "Change your telemetry opt out setting [True | False]")]
         public string TelemetryOptOut { get; set; }
 
         [Option("delete-run", Required = false, HelpText = "Delete a specific run from the database")]
@@ -306,7 +306,7 @@ namespace AttackSurfaceAnalyzer.Cli
                 if (opts.TelemetryOptOut != null)
                 {
                     Telemetry.SetOptOut(bool.Parse(opts.TelemetryOptOut));
-                    Log.Information("Your current telemetry opt out setting is {0}.", (bool.Parse(opts.TelemetryOptOut)) ? "Opted out" : "Opted in");
+                    Log.Information("Your telemetry opt out setting is now {0}.", (bool.Parse(opts.TelemetryOptOut)) ? "Opted out" : "Opted in");
                 }
                 if (opts.DeleteRunId != null)
                 {

--- a/Lib/Collectors/FileSystem/FileSystemMonitor.cs
+++ b/Lib/Collectors/FileSystem/FileSystemMonitor.cs
@@ -48,7 +48,7 @@ namespace AttackSurfaceAnalyzer.Collectors.FileSystem
 
         public override bool CanRunOnPlatform()
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         }
 
         public void Truncate(string runid)
@@ -217,7 +217,7 @@ namespace AttackSurfaceAnalyzer.Collectors.FileSystem
             if (getFileDetails && e.ChangeType != WatcherChangeTypes.Deleted)
             {
                 // Switch to using Mono here
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
                     var unixFileInfo = new Mono.Unix.UnixFileInfo(e.FullPath);
                     var result = unixFileInfo.FileAccessPermissions.ToString();
@@ -228,9 +228,6 @@ namespace AttackSurfaceAnalyzer.Collectors.FileSystem
                 {
                     // Found this example but it isn't working on osx
                     //FileSecurity fSecurity = File.GetAccessControl(e.FullPath);
-
-                    // @TODO
-                    //
                 }
             }
             WriteChange(e);


### PR DESCRIPTION
Fixes #99.

Temporarily removes linux support from FileSystemMonitor. See #70 