### PR TITLE
Fixes file system monitor on linux

### DIFF
--- a/Cli/Program.cs
+++ b/Cli/Program.cs
@@ -703,10 +703,18 @@ namespace AttackSurfaceAnalyzer.Cli
 
                 foreach (String dir in directories)
                 {
-                    foreach (NotifyFilters filter in filterOptions)
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                     {
-                        var newMon = new FileSystemMonitor(opts.RunId, dir, (filter != NotifyFilters.LastAccess) && opts.InterrogateChanges, filter);
-                        monitors.Add(newMon);
+                        var newMon = new FileSystemMonitor(opts.RunId, dir, false);
+                    }
+                    else
+                    {
+                        foreach (NotifyFilters filter in filterOptions)
+                        {
+                            Log.Information("Adding Path {0} Filter Type {1}", dir, filter.ToString());
+                            var newMon = new FileSystemMonitor(opts.RunId, dir, false, filter);
+                            monitors.Add(newMon);
+                        }
                     }
                 }
             }
@@ -740,7 +748,7 @@ namespace AttackSurfaceAnalyzer.Cli
                 aTimer.Enabled = true;
             }
 
-            foreach (var c in monitors)
+            foreach (FileSystemMonitor c in monitors)
             {
                 Log.Information("Executing: {0}", c.GetType().Name);
 

--- a/Lib/Collectors/FileSystem/FileSystemMonitor.cs
+++ b/Lib/Collectors/FileSystem/FileSystemMonitor.cs
@@ -107,6 +107,11 @@ namespace AttackSurfaceAnalyzer.Collectors.FileSystem
             cmd.Parameters.AddWithValue("@extended_results", "");
             cmd.Parameters.AddWithValue("@notify_filters", watcher.NotifyFilter.ToString());
             cmd.Parameters.AddWithValue("@serialized", JsonConvert.SerializeObject(obj));
+            FileSystemMonitorResult fileSystemObject = new FileSystemMonitorResult()
+            {
+                evt = obj,
+                filter = watcher.NotifyFilter
+            };
 
             cmd.ExecuteNonQuery();
         }

--- a/Lib/Objects/ResultObjects.cs
+++ b/Lib/Objects/ResultObjects.cs
@@ -3,6 +3,7 @@
 using AttackSurfaceAnalyzer.Collectors.FileSystem;
 using AttackSurfaceAnalyzer.ObjectTypes;
 using Serilog;
+using System.IO;
 
 namespace AttackSurfaceAnalyzer.ObjectTypes
 {
@@ -51,6 +52,12 @@ namespace AttackSurfaceAnalyzer.ObjectTypes
         {
             ResultType = RESULT_TYPE.FILE;
         }
+    }
+
+    public class FileSystemMonitorResult
+    {
+        public FileSystemEventArgs evt;
+        public NotifyFilters filter;
     }
 
     public class OpenPortResult: CompareResult


### PR DESCRIPTION
Fixes #70.

This change required trimming down the number of FileSystemMonitors which spawn on linux, reducing one data point, which was the type of change (i.e. access time, etc.) that spawned the event.  THis is being captured on Windows and OS X but due to the limitation found in #70 this won't work on linux.