### PR TITLE
Update package.json to be compatible with Electron at Microsoft build

### DIFF
--- a/Gui/package.json
+++ b/Gui/package.json
@@ -9,14 +9,15 @@
     "start": "tsc -p ."
   },
   "dependencies": {
-    "electron": "^4.1.3",
     "portscanner": "^2.2.0",
-    "socket.io": "^2.2.0"
+    "socket.io": "^2.2.0",
+    "electron": "4.1.1"
   },
   "devDependencies": {
     "@types/node": "^10.12.18",
     "@types/socket.io": "^2.1.2",
     "tslint": "^5.14.0",
-    "typescript": "^3.4.1"
+    "typescript": "^3.4.1",
+    "electron": "4.1.1"
   }
 }

--- a/Lib/Utils/Strings.cs
+++ b/Lib/Utils/Strings.cs
@@ -8,7 +8,6 @@ namespace AttackSurfaceAnalyzer.Utils
 {
     public static class Strings
     {
-//        var names = assembly.GetManifestResourceNames();
         public static string Get(string key)
         {
             return rm.GetString(key);
@@ -16,10 +15,9 @@ namespace AttackSurfaceAnalyzer.Utils
 
         public static void Setup()
         {
-            rm = new ResourceManager("AttackSurfaceAnalyzer.Properties.Resources", Assembly.GetEntryAssembly());
         }
 
         // Default locale
-        static ResourceManager rm;
+        static ResourceManager rm = new ResourceManager("AttackSurfaceAnalyzer.Properties.Resources", Assembly.GetEntryAssembly());
     }
 }


### PR DESCRIPTION
We need to have package.json lock the electron version to exactly the one we drop in the cache, which at the moment is 4.1.1.

Fixes #125.