### PR TITLE
Fixes first run detection

### DIFF
--- a/Cli/Program.cs
+++ b/Cli/Program.cs
@@ -238,15 +238,6 @@ namespace AttackSurfaceAnalyzer
 
             Strings.Setup();
 
-            if (DatabaseManager.IsFirstRun())
-            {
-                _isFirstRun = true;
-                string exeStr = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "AttackSurfaceAnalyzerCli.exe config --telemetry-opt-out true" : "AttackSurfaceAnalyzerCli config --telemetry-opt-out true";
-                Log.Information(Strings.Get("ApplicationHasTelemetry"));
-                Log.Information(Strings.Get("ApplicationHasTelemetry2"), "https://github.com/Microsoft/AttackSurfaceAnalyzer/blob/master/PRIVACY.md");
-                Log.Information(Strings.Get("ApplicationHasTelemetry3"), exeStr);
-            }
-
             var argsResult = Parser.Default.ParseArguments<CollectCommandOptions, CompareCommandOptions, MonitorCommandOptions, ExportMonitorCommandOptions, ExportCollectCommandOptions, ConfigCommandOptions>(args)
                 .MapResult(
                     (CollectCommandOptions opts) => RunCollectCommand(opts),
@@ -265,6 +256,7 @@ namespace AttackSurfaceAnalyzer
         {
             DatabaseManager.SqliteFilename = opts.DatabaseFilename;
             DatabaseManager.Setup();
+            CheckFirstRun();
             Telemetry.Setup(Gui: false);
 
             if (opts.ResetDatabase)
@@ -436,6 +428,7 @@ namespace AttackSurfaceAnalyzer
             Log.Debug("{0} RunExportCollectCommand", Strings.Get("Begin"));
             DatabaseManager.SqliteFilename = opts.DatabaseFilename;
             DatabaseManager.Setup();
+            CheckFirstRun();
             Telemetry.Setup(Gui: false);
             DatabaseManager.VerifySchemaVersion();
 
@@ -676,6 +669,18 @@ namespace AttackSurfaceAnalyzer
 
         }
 
+        private static void CheckFirstRun()
+        {
+            if (DatabaseManager.IsFirstRun())
+            {
+                _isFirstRun = true;
+                string exeStr = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "AttackSurfaceAnalyzerCli.exe config --telemetry-opt-out true" : "AttackSurfaceAnalyzerCli config --telemetry-opt-out true";
+                Log.Information(Strings.Get("ApplicationHasTelemetry"));
+                Log.Information(Strings.Get("ApplicationHasTelemetry2"), "https://github.com/Microsoft/AttackSurfaceAnalyzer/blob/master/PRIVACY.md");
+                Log.Information(Strings.Get("ApplicationHasTelemetry3"), exeStr);
+            }
+        }
+
         private static int RunExportMonitorCommand(ExportMonitorCommandOptions opts)
         {
 #if DEBUG
@@ -685,12 +690,12 @@ namespace AttackSurfaceAnalyzer
 #endif
             DatabaseManager.SqliteFilename = opts.DatabaseFilename;
             DatabaseManager.Setup();
+            CheckFirstRun();
             Telemetry.Setup(Gui: false);
             DatabaseManager.VerifySchemaVersion();
 
             if (opts.RunId.Equals("Timestamp"))
             {
-
                 List<string> runIds = DatabaseManager.GetLatestRunIds(1, "monitor");
 
                 if (runIds.Count < 1)
@@ -768,6 +773,7 @@ namespace AttackSurfaceAnalyzer
 #endif
             DatabaseManager.SqliteFilename = opts.DatabaseFilename;
             DatabaseManager.Setup();
+            CheckFirstRun();
             Telemetry.Setup(Gui: false);
             DatabaseManager.VerifySchemaVersion();
 
@@ -1241,6 +1247,7 @@ namespace AttackSurfaceAnalyzer
             AdminOrQuit();
             DatabaseManager.SqliteFilename = opts.DatabaseFilename;
             DatabaseManager.Setup();
+            CheckFirstRun();
             Telemetry.Setup(Gui: false);
             DatabaseManager.VerifySchemaVersion();
 
@@ -1461,6 +1468,7 @@ namespace AttackSurfaceAnalyzer
 #endif
             DatabaseManager.SqliteFilename = opts.DatabaseFilename;
             DatabaseManager.Setup();
+            CheckFirstRun();
             Telemetry.Setup(Gui: false);
             DatabaseManager.VerifySchemaVersion();
 

--- a/Lib/Utils/DatabaseManager.cs
+++ b/Lib/Utils/DatabaseManager.cs
@@ -127,7 +127,7 @@ namespace AttackSurfaceAnalyzer.Utils
 
                     cmd.CommandText = SQL_CREATE_DEFAULT_SETTINGS;
                     cmd.Parameters.AddWithValue("@schema_version", SCHEMA_VERSION);
-                    _firstRun &= cmd.ExecuteNonQuery() != 0;                
+                    _firstRun &= cmd.ExecuteNonQuery() != 0;        
 
                     cmd.CommandText = SQL_CREATE_FILE_SYSTEM_INDEX;
                     cmd.ExecuteNonQuery();


### PR DESCRIPTION
Previous changes to prevent creation of empty default database regressed first run detection. This resolves that.

Fix #207 