### PR TITLE
Gfs/#29

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+out/
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/Cli/AttackSurfaceAnalyzerCli.csproj
+++ b/Cli/AttackSurfaceAnalyzerCli.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.5.0" />
+    <PackageReference Include="ILLink.Tasks" Version="0.1.5-preview-1841731" />
     <PackageReference Include="RazorLight" Version="2.0.0-beta1" />
     <PackageReference Include="System.Management" Version="4.6.0-preview.19073.11" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/Cli/Program.cs
+++ b/Cli/Program.cs
@@ -1217,6 +1217,7 @@ namespace AttackSurfaceAnalyzer
                 if (!Elevation.IsAdministrator())
                 {
                     Log.Fatal(Strings.Get("Err_RunAsAdmin"));
+                    Log.CloseAndFlush();
                     Environment.Exit(1);
                 }
             }
@@ -1225,6 +1226,7 @@ namespace AttackSurfaceAnalyzer
                 if (!Elevation.IsRunningAsRoot())
                 {
                     Log.Fatal(Strings.Get("Err_RunAsRoot"));
+                    Log.CloseAndFlush();
                     Environment.Exit(1);
                 }
             }
@@ -1233,6 +1235,7 @@ namespace AttackSurfaceAnalyzer
                 if (!Elevation.IsRunningAsRoot())
                 {
                     Log.Fatal(Strings.Get("Err_RunAsRoot"));
+                    Log.CloseAndFlush();
                     Environment.Exit(1);
                 }
             }

--- a/Lib/Utils/DatabaseManager.cs
+++ b/Lib/Utils/DatabaseManager.cs
@@ -82,10 +82,8 @@ namespace AttackSurfaceAnalyzer.Utils
 
         public static bool Setup()
         {
-            Log.Warning("Before Conn Check");
             if (Connection == null)
             {
-                Log.Warning("After Conn Check");
 
                 Connection = new SqliteConnection($"Filename=" + _SqliteFilename);
                 Connection.Open();

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="Custom Electron.NET" value="tools/packages" />
+    <add key="Dotnet IL Link" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Uses [.NET IL Linker](https://github.com/dotnet/core/blob/master/samples/linker-instructions.md) to create single shrunken binary.

From ~135 MB, 556 files to 2.88 MB, 15 files (Including symbols)

Fix #29.
Fix #228.
