### PR TITLE
Gfs/#246

### DIFF
--- a/Cli/Program.cs
+++ b/Cli/Program.cs
@@ -144,7 +144,7 @@ namespace AttackSurfaceAnalyzer
         [Option("directories", Required = false, HelpText = "Comma separated list of paths to scan with FileSystemCollector")]
         public string SelectedDirectories { get; set; }
 
-        [Option("certificate-files", Default = false, HelpText = "Scan the filesystem for certificates (high overhead)."]
+        [Option("certificate-files", Default = false, HelpText = "Scan the filesystem for certificates (high overhead).")]
         public bool CertificatesFromFiles { get; set; }
 
         [Option(HelpText = "Download files from thin Cloud Folders (like OneDrive) to check them.", Default = false)]
@@ -1212,7 +1212,7 @@ namespace AttackSurfaceAnalyzer
             }
             if (opts.EnableCertificateCollector || opts.EnableAllCollectors)
             {
-                collectors.Add(new CertificateCollector(opts.RunId));
+                collectors.Add(new CertificateCollector(opts.RunId,opts.CertificatesFromFiles));
             }
 
             if (collectors.Count == 0)

--- a/Cli/Program.cs
+++ b/Cli/Program.cs
@@ -144,6 +144,9 @@ namespace AttackSurfaceAnalyzer
         [Option("directories", Required = false, HelpText = "Comma separated list of paths to scan with FileSystemCollector")]
         public string SelectedDirectories { get; set; }
 
+        [Option("certificate-files", Default = false, HelpText = "Scan the filesystem for certificates (high overhead)."]
+        public bool CertificatesFromFiles { get; set; }
+
         [Option(HelpText = "Download files from thin Cloud Folders (like OneDrive) to check them.", Default = false)]
         public bool DownloadCloud { get; set; }
 

--- a/Lib/Collectors/CertificateCollector.cs
+++ b/Lib/Collectors/CertificateCollector.cs
@@ -76,14 +76,14 @@ namespace AttackSurfaceAnalyzer.Collectors
                                             }
                                             if (fileInfo.FullName.EndsWith(".cer", StringComparison.CurrentCulture))
                                             {
-                                                var certificate = new X509Certificate2(File.ReadAllBytes(fileInfo.FullName));
+                                                var certificate = X509Certificate.CreateFromCertFile(fileInfo.FullName);
                                                 var obj = new CertificateObject()
                                                 {
                                                     StoreLocation = fileInfo.FullName,
                                                     StoreName = "Disk",
                                                     CertificateHashString = certificate.GetCertHashString(),
                                                     Subject = certificate.Subject,
-                                                    Pkcs12 = certificate.HasPrivateKey ? "redacted" : certificate.Export(X509ContentType.Pkcs12).ToString()
+                                                    Pkcs12 = certificate.Export(X509ContentType.Pkcs12).ToString()
                                                 };
                                                 DatabaseManager.Write(obj, this.runId);
                                             }
@@ -91,7 +91,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                                         catch (Exception e)
                                         {
                                             Log.Debug("Couldn't parse certificate file {0}", fileInfo.FullName);
-                                            Log.Debug(e.StackTrace);
+                                            Log.Debug("{0} {1}-{2}",e.GetType().ToString(), e.Message, e.StackTrace);
                                         }
                                     }));
 

--- a/Lib/Collectors/CertificateCollector.cs
+++ b/Lib/Collectors/CertificateCollector.cs
@@ -42,7 +42,61 @@ namespace AttackSurfaceAnalyzer.Collectors
 
             if (gatherFromFiles)
             {
+                var roots = new List<string>();
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    foreach (var driveInfo in DriveInfo.GetDrives())
+                    {
+                        if (driveInfo.IsReady && driveInfo.DriveType == DriveType.Fixed)
+                        {
+                            roots.Add(driveInfo.Name);
+                        }
+                    }
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    roots.Add("/");   // @TODO Improve this
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    roots.Add("/"); // @TODO Improve this
+                }
+                foreach (var root in roots)
+                {
 
+                    var fileInfoEnumerable = DirectoryWalker.WalkDirectory(root, "Certificate");
+                    Parallel.ForEach(fileInfoEnumerable,
+                                    (fileInfo =>
+                                    {
+                                        try
+                                        {
+                                            if (fileInfo is DirectoryInfo)
+                                            {
+                                                return;
+                                            }
+                                            if (fileInfo.FullName.EndsWith(".cer", StringComparison.CurrentCulture))
+                                            {
+                                                var certificate = new X509Certificate2(File.ReadAllBytes(fileInfo.FullName));
+                                                var obj = new CertificateObject()
+                                                {
+                                                    StoreLocation = fileInfo.FullName,
+                                                    StoreName = "Disk",
+                                                    CertificateHashString = certificate.GetCertHashString(),
+                                                    Subject = certificate.Subject,
+                                                    Pkcs12 = certificate.HasPrivateKey ? "redacted" : certificate.Export(X509ContentType.Pkcs12).ToString()
+                                                };
+                                                DatabaseManager.Write(obj, this.runId);
+                                            }
+                                        }
+                                        catch (Exception e)
+                                        {
+                                            Log.Debug("Couldn't parse certificate file {0}", fileInfo.FullName);
+                                            Log.Debug(e.StackTrace);
+                                        }
+                                    }));
+
+
+                }
             }
 
             // On Windows we can use the .NET API to iterate through all the stores.

--- a/Lib/Collectors/CertificateCollector.cs
+++ b/Lib/Collectors/CertificateCollector.cs
@@ -18,9 +18,12 @@ namespace AttackSurfaceAnalyzer.Collectors
     /// </summary>
     public class CertificateCollector : BaseCollector
     {
-        public CertificateCollector(string runId)
+        private bool gatherFromFiles = false;
+
+        public CertificateCollector(string runId, bool gatherFromFiles)
         {
             this.runId = runId;
+            this.gatherFromFiles = gatherFromFiles;
         }
 
         public override bool CanRunOnPlatform()
@@ -36,6 +39,11 @@ namespace AttackSurfaceAnalyzer.Collectors
             }
 
             Start();
+
+            if (gatherFromFiles)
+            {
+
+            }
 
             // On Windows we can use the .NET API to iterate through all the stores.
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -76,9 +84,7 @@ namespace AttackSurfaceAnalyzer.Collectors
             // On linux we check the central trusted root store (a folder), which has symlinks to actual cert locations scattered across the db
             // We list all the certificates and then create a new X509Certificate2 object for each by filename.
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                
-
+            {                
                 var result = ExternalCommandRunner.RunExternalCommand("ls", new string[] { "/etc/ssl/certs", "-A" });
                 Log.Debug("{0}", result);
 

--- a/Lib/Objects/Types.cs
+++ b/Lib/Objects/Types.cs
@@ -75,7 +75,8 @@ namespace AttackSurfaceAnalyzer.Objects
         LT,
         GT,
         CONTAINS,
-        WAS_MODIFIED
+        WAS_MODIFIED,
+        ENDS_WITH
     }
 
     public enum PLATFORM

--- a/Lib/Utils/Analyzer.cs
+++ b/Lib/Utils/Analyzer.cs
@@ -198,6 +198,21 @@ namespace AttackSurfaceAnalyzer.Utils
                                 break;
                             }
                             return DEFAULT_RESULT_TYPE_MAP[compareResult.ResultType];
+                        case OPERATION.ENDS_WITH:
+                            foreach (string datum in clause.data)
+                            {
+                                foreach (var val in valsToCheck)
+                                {
+                                    if (val.EndsWith(datum, StringComparison.CurrentCulture))
+                                    {
+                                        complete = true;
+                                        break;
+                                    }
+                                }
+                                if (complete) { break; }
+                            }
+                            if (complete) { break; }
+                            return DEFAULT_RESULT_TYPE_MAP[compareResult.ResultType];
                         default:
                             Log.Debug("Unimplemented operation {0}", clause.op);
                             return DEFAULT_RESULT_TYPE_MAP[compareResult.ResultType];

--- a/Lib/Utils/DirectoryWalker.cs
+++ b/Lib/Utils/DirectoryWalker.cs
@@ -9,7 +9,7 @@ namespace AttackSurfaceAnalyzer.Utils
 {
     public class DirectoryWalker
     {     
-        public static IEnumerable<FileSystemInfo> WalkDirectory(string root)
+        public static IEnumerable<FileSystemInfo> WalkDirectory(string root, string filterPlatform)
         {
             // Data structure to hold names of subfolders to be
             // examined for files.
@@ -25,7 +25,7 @@ namespace AttackSurfaceAnalyzer.Utils
             {
                 string currentDir = dirs.Pop();
                 Log.Verbose(currentDir);
-                if (Filter.IsFiltered(Helpers.GetPlatformString(), "Scan", "File", "Path", currentDir))
+                if (Filter.IsFiltered(filterPlatform, "Scan", "File", "Path", currentDir))
                 {
                     continue;
                 }
@@ -101,7 +101,7 @@ namespace AttackSurfaceAnalyzer.Utils
                         Log.Debug(e.Message);
                         continue;
                     }
-                    if (Filter.IsFiltered(Helpers.GetPlatformString(), "Scan", "File", "Path", file))
+                    if (Filter.IsFiltered(filterPlatform, "Scan", "File", "Path", file))
                     {
                         continue;
                     }
@@ -126,7 +126,7 @@ namespace AttackSurfaceAnalyzer.Utils
                             continue;
                         }
                     }
-                    catch (System.IO.DirectoryNotFoundException e)
+                    catch (System.IO.DirectoryNotFoundException)
                     {
                         // If file was deleted by a separate application
                         //  or thread since the call to TraverseTree()

--- a/Lib/Utils/DirectoryWalker.cs
+++ b/Lib/Utils/DirectoryWalker.cs
@@ -131,8 +131,7 @@ namespace AttackSurfaceAnalyzer.Utils
                         // If file was deleted by a separate application
                         //  or thread since the call to TraverseTree()
                         // then just continue.
-                        Log.Debug(e.Message);
-                        Log.Debug(e.GetType().ToString());
+                        
 
                         continue;
                     }

--- a/Lib/Utils/Filter.cs
+++ b/Lib/Utils/Filter.cs
@@ -12,7 +12,10 @@ namespace AttackSurfaceAnalyzer.Utils
     public static class Filter
     {
         static JObject config = null;
-        static Dictionary<string, List<Regex>> _filters = new Dictionary<string, List<Regex>>();
+        static Dictionary<string, List<Regex>> _filters = new Dictionary<string, List<Regex>>() {
+            { "Certificates:Scan:File:Path:Include",new List<Regex>(){ new Regex("^.*\\.cer$") } },
+            { "Certificates:Scan:File:Path:Exclude",new List<Regex>(){ new Regex(".*") } }
+        };
 
         public static bool IsFiltered(string Platform, string ScanType, string ItemType, string Property, string Target)
         {
@@ -38,7 +41,7 @@ namespace AttackSurfaceAnalyzer.Utils
             }
             try
             {
-                string key = String.Format("{0}{1}{2}{3}{4}", Platform, ScanType, ItemType, Property, FilterType);
+                string key = String.Format("{0}:{1}:{2}:{3}:{4}", Platform, ScanType, ItemType, Property, FilterType);
                 List<Regex> filters = new List<Regex>();
 
                 try

--- a/analyses.json
+++ b/analyses.json
@@ -60,24 +60,46 @@
       ]
     },
     {
-      "name": "Executables",
-      "desc": "Flag when executables are created.",
-      "flag": "INFORMATION",
-      "platforms": [
-        "LINUX",
-        "MACOS",
-        "WINDOWS"
-      ],
-      "resultType": "FILE",
-      "clauses": [
-        {
-          "field": "IsExecutable",
-          "op": "EQ",
-          "data": [
-            "True"
-          ]
-        }
-      ]
+        "name": "Executables",
+        "desc": "Flag when executables are created.",
+        "flag": "INFORMATION",
+        "platforms": [
+            "LINUX",
+            "MACOS",
+            "WINDOWS"
+        ],
+        "resultType": "FILE",
+        "clauses": [
+            {
+                "field": "IsExecutable",
+                "op": "EQ",
+                "data": [
+                    "True"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Certificates",
+        "desc": "Flag when executables are placed on disk.",
+        "flag": "INFORMATION",
+        "platforms": [
+            "LINUX",
+            "MACOS",
+            "WINDOWS"
+        ],
+        "resultType": "FILE",
+        "clauses": [
+            {
+                "field": "Path",
+                "op": "ENDS_WITH",
+                "data": [
+                    ".cer",
+                    ".der",
+                    ".crt"
+                ]
+            }
+        ]
     }
   ],
  "meta": {


### PR DESCRIPTION
@Guydalf 
Fixes #246 with two options.  

The first, enabled by default is to flag certificate files during analysis, the rule is now included in analysis.json which ships with ASA. 

The second, not enabled by default, adds the option to do a full disk crawl just looking for certificate files.  I tested this and it takes about a minute on my laptop.