### PR TITLE
Use dotnet 3.1.x instead of 3.1.100

### DIFF
--- a/Pipelines/pr-validation.yml
+++ b/Pipelines/pr-validation.yml
@@ -33,7 +33,7 @@ stages:
     - task: UseDotNet@2
       inputs:
         packageType: 'sdk'
-        version: '3.1.100'
+        version: '3.1.x'
 
     - task: DotNetCoreCLI@2
       displayName: 'Build Tests'

--- a/Pipelines/release.yml
+++ b/Pipelines/release.yml
@@ -29,7 +29,7 @@ stages:
     - task: UseDotNet@2
       inputs:
         packageType: 'sdk'
-        version: '3.1.100'
+        version: '3.1.x'
 
     - task: DotNetCoreCLI@2
       displayName: 'Build Tests'

--- a/Pipelines/sdl.yml
+++ b/Pipelines/sdl.yml
@@ -23,10 +23,10 @@ variables:
 
 steps:
 - task: UseDotNet@2
-  displayName: Use DotNet 3.1.100
+  displayName: Use DotNet 3.1
   inputs:
     packageType: 'sdk'
-    version: '3.1.100'
+    version: '3.1.x'
 
 - script: 'dotnet tool install -g nbgv'
   displayName: 'Install GitVersioning'


### PR DESCRIPTION
This should automatically use the latest version of .NET Core 3.1 in the build pipeline without having to manually update the pipeline.