### PR TITLE
Demand read permissions once

### DIFF
--- a/Lib/Collectors/FileSystemCollector.cs
+++ b/Lib/Collectors/FileSystemCollector.cs
@@ -31,7 +31,6 @@ namespace AttackSurfaceAnalyzer.Collectors
         private readonly bool INCLUDE_CONTENT_HASH;
         private readonly bool downloadCloud;
         private readonly bool parallel;
-        private readonly CollectCommandOptions opts;
 
         public static Dictionary<string, uint> ClusterSizes { get; set; } = new Dictionary<string, uint>();
 
@@ -402,10 +401,10 @@ namespace AttackSurfaceAnalyzer.Collectors
             {
                 try
                 {
-                    GetDiskFreeSpace(path.FullName, out uint lpSectorsPerCluster, out uint lpBytesPerSector, out _, out _);
+                    NativeMethods.GetDiskFreeSpace(path.FullName, out uint lpSectorsPerCluster, out uint lpBytesPerSector, out _, out _);
 
                     uint clusterSize = lpSectorsPerCluster * lpBytesPerSector;
-                    uint lowSize = GetCompressedFileSizeW(path.FullName, out uint highSize);
+                    uint lowSize = NativeMethods.GetCompressedFileSizeW(path.FullName, out uint highSize);
                     long size = (long)highSize << 32 | lowSize;
                     return ((size + clusterSize - 1) / clusterSize) * clusterSize;
                 }
@@ -428,17 +427,5 @@ namespace AttackSurfaceAnalyzer.Collectors
                 }
             }
         }
-
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        static extern bool GetDiskFreeSpace([In, MarshalAs(UnmanagedType.LPWStr)] string lpRootPathName,
-           out uint lpSectorsPerCluster,
-           out uint lpBytesPerSector,
-           out uint lpNumberOfFreeClusters,
-           out uint lpTotalNumberOfClusters);
-
-        [DllImport("kernel32.dll")]
-        static extern uint GetCompressedFileSizeW(
-            [In, MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
-            [Out, MarshalAs(UnmanagedType.U4)] out uint lpFileSizeHigh);
     }
 }

--- a/Lib/Collectors/FileSystemUtils.cs
+++ b/Lib/Collectors/FileSystemUtils.cs
@@ -237,10 +237,8 @@ namespace AttackSurfaceAnalyzer.Collectors
             byte[] fourBytes = new byte[4];
             try
             {
-                using (var fileStream = File.Open(Path, FileMode.Open))
-                {
-                    fileStream.Read(fourBytes, 0, 4);
-                }
+                using var fileStream = File.Open(Path, FileMode.Open);
+                fileStream.Read(fourBytes, 0, 4);
             }
             catch (Exception e) when (
                 e is ArgumentException
@@ -258,7 +256,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                 return false;
             }
 
-            return MacMagicNumbers.Contains(fourBytes);
+            return MacMagicNumbers.Any(x => x.SequenceEqual(fourBytes));
         }
 
         public static bool IsWindowsExecutable(string? Path, ulong? Size)

--- a/Lib/Collectors/RegistryCollector.cs
+++ b/Lib/Collectors/RegistryCollector.cs
@@ -19,7 +19,6 @@ namespace AttackSurfaceAnalyzer.Collectors
     {
         private readonly List<(RegistryHive, string)> Hives;
         private readonly bool Parallelize;
-        private readonly CollectCommandOptions opts;
 
         private static readonly List<(RegistryHive, string)> DefaultHives = new List<(RegistryHive, string)>()
         {

--- a/Lib/Lib.csproj
+++ b/Lib/Lib.csproj
@@ -39,9 +39,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.3" />
-    <PackageReference Include="Microsoft.PowerShell.Commands.Diagnostics" Version="7.0.0" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.4" />
+    <PackageReference Include="Microsoft.PowerShell.Commands.Diagnostics" Version="7.0.1" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.1" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="3.1.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />
@@ -66,7 +66,7 @@
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="sqlite" Version="3.13.0" />
     <PackageReference Include="Microsoft.TSS" Version="2.1.1" />
-    <PackageReference Include="PeNet" Version="2.2.6" />
+    <PackageReference Include="PeNet" Version="2.2.7" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\analyses.json" Link="analyses.json" />

--- a/Lib/Objects/FileSystemObject.cs
+++ b/Lib/Objects/FileSystemObject.cs
@@ -94,6 +94,7 @@ namespace AttackSurfaceAnalyzer.Objects
         /// When was the file created in UTC
         /// </summary>
         public DateTime Created { get; set; }
+        public long SizeOnDisk { get; internal set; }
 
         public bool ShouldSerializeCharacteristics()
         {

--- a/Lib/Utils/NativeMethods.cs
+++ b/Lib/Utils/NativeMethods.cs
@@ -191,6 +191,17 @@ namespace AttackSurfaceAnalyzer.Utils
 
     internal class NativeMethods
     {
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        internal static extern bool GetDiskFreeSpace([In, MarshalAs(UnmanagedType.LPWStr)] string lpRootPathName,
+           out uint lpSectorsPerCluster,
+           out uint lpBytesPerSector,
+           out uint lpNumberOfFreeClusters,
+           out uint lpTotalNumberOfClusters);
+
+        [DllImport("kernel32.dll")]
+        internal static extern uint GetCompressedFileSizeW(
+            [In, MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+            [Out, MarshalAs(UnmanagedType.U4)] out uint lpFileSizeHigh);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         internal static extern bool CloseHandle(IntPtr handle);


### PR DESCRIPTION
If we can read a file we do a bunch of things like reading bytes to check if its an executable and inspecting it for a signature.  

Previously we called functions that Try to do each of those things, so if we get permission denied once we would keep trying other things triggering more exceptions.  

Now we check if we can read once and pop out if we can't and then call those Try functions which may still have other exceptions but (hopefully) won't have security or permissions exceptions.

This should result in a minor performance improvement since we avoid exceptions.