### PR TITLE
Better Exception Handling in Collectors

### DIFF
--- a/Cli/Program.cs
+++ b/Cli/Program.cs
@@ -1074,7 +1074,10 @@ namespace AttackSurfaceAnalyzer.Cli
                 {
                     DatabaseManager.BeginTransaction();
 
-                    Task.Run(() => c.Execute());
+                    Task.Run(() =>
+                    {
+                        try { c.Execute(); } catch (Exception e) { Log.Warning(e,"Error running {c}", c.GetType()); }
+                    });
 
                     Thread.Sleep(1);
 

--- a/Lib/Collectors/ServiceCollector.cs
+++ b/Lib/Collectors/ServiceCollector.cs
@@ -36,96 +36,108 @@ namespace AttackSurfaceAnalyzer.Collectors
         /// </summary>
         public void ExecuteWindows()
         {
-            var fsc = new FileSystemCollector(new CollectCommandOptions() { SingleThread = opts.SingleThread });
-            System.Management.SelectQuery sQuery = new System.Management.SelectQuery("select * from Win32_Service"); // where name = '{0}'", "MCShield.exe"));
-            using System.Management.ManagementObjectSearcher mgmtSearcher = new System.Management.ManagementObjectSearcher(sQuery);
-            foreach (System.Management.ManagementObject service in mgmtSearcher.Get())
+            try
             {
-                try
+                System.Management.SelectQuery sQuery = new System.Management.SelectQuery("select * from Win32_Service"); // where name = '{0}'", "MCShield.exe"));
+                using System.Management.ManagementObjectSearcher mgmtSearcher = new System.Management.ManagementObjectSearcher(sQuery);
+                foreach (System.Management.ManagementObject service in mgmtSearcher.Get())
                 {
-                    var val = service.GetPropertyValue("Name").ToString();
-                    if (val != null)
+                    try
                     {
-                        var obj = new ServiceObject(val);
-
-                        val = service.GetPropertyValue("AcceptPause")?.ToString();
-                        if (!string.IsNullOrEmpty(val))
-                            obj.AcceptPause = bool.Parse(val);
-
-                        val = service.GetPropertyValue("AcceptStop")?.ToString();
-                        if (!string.IsNullOrEmpty(val))
-                            obj.AcceptStop = bool.Parse(val);
-
-                        obj.Caption = service.GetPropertyValue("Caption")?.ToString();
-
-                        val = service.GetPropertyValue("CheckPoint")?.ToString();
-                        if (!string.IsNullOrEmpty(val))
-                            obj.CheckPoint = uint.Parse(val, CultureInfo.InvariantCulture);
-
-                        obj.CreationClassName = service.GetPropertyValue("CreationClassName")?.ToString();
-
-                        val = service.GetPropertyValue("DelayedAutoStart")?.ToString();
-                        if (!string.IsNullOrEmpty(val))
-                            obj.DelayedAutoStart = bool.Parse(val);
-
-                        obj.Description = service.GetPropertyValue("Description")?.ToString();
-
-                        val = service.GetPropertyValue("DesktopInteract")?.ToString();
-                        if (!string.IsNullOrEmpty(val))
-                            obj.DesktopInteract = bool.Parse(val);
-
-                        obj.DisplayName = service.GetPropertyValue("DisplayName")?.ToString();
-                        obj.ErrorControl = service.GetPropertyValue("ErrorControl")?.ToString();
-
-                        val = service.GetPropertyValue("ExitCode")?.ToString();
-                        if (!string.IsNullOrEmpty(val))
-                            obj.ExitCode = uint.Parse(val, CultureInfo.InvariantCulture);
-
-                        if (DateTime.TryParse(service.GetPropertyValue("InstallDate")?.ToString(), out DateTime dateTime))
+                        var val = service.GetPropertyValue("Name").ToString();
+                        if (val != null)
                         {
-                            obj.InstallDate = dateTime;
+                            var obj = new ServiceObject(val);
+
+                            val = service.GetPropertyValue("AcceptPause")?.ToString();
+                            if (!string.IsNullOrEmpty(val))
+                                obj.AcceptPause = bool.Parse(val);
+
+                            val = service.GetPropertyValue("AcceptStop")?.ToString();
+                            if (!string.IsNullOrEmpty(val))
+                                obj.AcceptStop = bool.Parse(val);
+
+                            obj.Caption = service.GetPropertyValue("Caption")?.ToString();
+
+                            val = service.GetPropertyValue("CheckPoint")?.ToString();
+                            if (!string.IsNullOrEmpty(val))
+                                obj.CheckPoint = uint.Parse(val, CultureInfo.InvariantCulture);
+
+                            obj.CreationClassName = service.GetPropertyValue("CreationClassName")?.ToString();
+
+                            val = service.GetPropertyValue("DelayedAutoStart")?.ToString();
+                            if (!string.IsNullOrEmpty(val))
+                                obj.DelayedAutoStart = bool.Parse(val);
+
+                            obj.Description = service.GetPropertyValue("Description")?.ToString();
+
+                            val = service.GetPropertyValue("DesktopInteract")?.ToString();
+                            if (!string.IsNullOrEmpty(val))
+                                obj.DesktopInteract = bool.Parse(val);
+
+                            obj.DisplayName = service.GetPropertyValue("DisplayName")?.ToString();
+                            obj.ErrorControl = service.GetPropertyValue("ErrorControl")?.ToString();
+
+                            val = service.GetPropertyValue("ExitCode")?.ToString();
+                            if (!string.IsNullOrEmpty(val))
+                                obj.ExitCode = uint.Parse(val, CultureInfo.InvariantCulture);
+
+                            if (DateTime.TryParse(service.GetPropertyValue("InstallDate")?.ToString(), out DateTime dateTime))
+                            {
+                                obj.InstallDate = dateTime;
+                            }
+                            obj.PathName = service.GetPropertyValue("PathName")?.ToString();
+
+                            val = service.GetPropertyValue("ProcessId")?.ToString();
+                            if (!string.IsNullOrEmpty(val))
+                                obj.ProcessId = uint.Parse(val, CultureInfo.InvariantCulture);
+
+                            val = service.GetPropertyValue("ServiceSpecificExitCode")?.ToString();
+                            if (!string.IsNullOrEmpty(val))
+                                obj.ServiceSpecificExitCode = uint.Parse(val, CultureInfo.InvariantCulture);
+
+                            obj.ServiceType = service.GetPropertyValue("ServiceType")?.ToString();
+
+                            val = service.GetPropertyValue("Started").ToString();
+                            if (!string.IsNullOrEmpty(val))
+                                obj.Started = bool.Parse(val);
+
+                            obj.StartMode = service.GetPropertyValue("StartMode")?.ToString();
+                            obj.StartName = service.GetPropertyValue("StartName")?.ToString();
+                            obj.State = service.GetPropertyValue("State")?.ToString();
+                            obj.Status = service.GetPropertyValue("Status")?.ToString();
+                            obj.SystemCreationClassName = service.GetPropertyValue("SystemCreationClassName")?.ToString();
+                            obj.SystemName = service.GetPropertyValue("SystemName")?.ToString();
+
+                            val = service.GetPropertyValue("TagId")?.ToString();
+                            if (!string.IsNullOrEmpty(val))
+                                obj.TagId = uint.Parse(val, CultureInfo.InvariantCulture);
+
+                            val = service.GetPropertyValue("WaitHint")?.ToString();
+                            if (!string.IsNullOrEmpty(val))
+                                obj.WaitHint = uint.Parse(val, CultureInfo.InvariantCulture);
+
+                            Results.Push(obj);
                         }
-                        obj.PathName = service.GetPropertyValue("PathName")?.ToString();
-
-                        val = service.GetPropertyValue("ProcessId")?.ToString();
-                        if (!string.IsNullOrEmpty(val))
-                            obj.ProcessId = uint.Parse(val, CultureInfo.InvariantCulture);
-
-                        val = service.GetPropertyValue("ServiceSpecificExitCode")?.ToString();
-                        if (!string.IsNullOrEmpty(val))
-                            obj.ServiceSpecificExitCode = uint.Parse(val, CultureInfo.InvariantCulture);
-
-                        obj.ServiceType = service.GetPropertyValue("ServiceType")?.ToString();
-
-                        val = service.GetPropertyValue("Started").ToString();
-                        if (!string.IsNullOrEmpty(val))
-                            obj.Started = bool.Parse(val);
-
-                        obj.StartMode = service.GetPropertyValue("StartMode")?.ToString();
-                        obj.StartName = service.GetPropertyValue("StartName")?.ToString();
-                        obj.State = service.GetPropertyValue("State")?.ToString();
-                        obj.Status = service.GetPropertyValue("Status")?.ToString();
-                        obj.SystemCreationClassName = service.GetPropertyValue("SystemCreationClassName")?.ToString();
-                        obj.SystemName = service.GetPropertyValue("SystemName")?.ToString();
-
-                        val = service.GetPropertyValue("TagId")?.ToString();
-                        if (!string.IsNullOrEmpty(val))
-                            obj.TagId = uint.Parse(val, CultureInfo.InvariantCulture);
-
-                        val = service.GetPropertyValue("WaitHint")?.ToString();
-                        if (!string.IsNullOrEmpty(val))
-                            obj.WaitHint = uint.Parse(val, CultureInfo.InvariantCulture);
-
-                        Results.Push(obj);
+                    }
+                    catch (Exception e) when (
+                        e is TypeInitializationException ||
+                        e is PlatformNotSupportedException)
+                    {
+                        Log.Warning(Strings.Get("CollectorNotSupportedOnPlatform"), GetType().ToString());
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Warning(e, "Failed to grok Service Collector object at {0}.",service.Path);
                     }
                 }
-                catch (Exception e) when (
-                    e is TypeInitializationException ||
-                    e is PlatformNotSupportedException)
-                {
-                    Log.Warning(Strings.Get("CollectorNotSupportedOnPlatform"), GetType().ToString());
-                }
             }
+            catch (Exception e)
+            {
+                Log.Warning(e, "Failed to run Service Collector.");
+            }
+
+            var fsc = new FileSystemCollector(new CollectCommandOptions() { SingleThread = opts.SingleThread });
 
             foreach (var file in Directory.EnumerateFiles("C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Startup"))
             {

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ All data collected is stored in a set of local SQLite databases.
 Run the following commands in an Administrator Shell (or as root).  Replace ```asa``` with ```asa.exe``` as appropriate for your platform.
 
 ### CLI Mode
-To start a default all collectors run: ```asa collect```
+To start a default all collectors run: ```asa collect -a```
 
 To compare the last two collection runs: ```asa export-collect```
 


### PR DESCRIPTION
Fix #453 
Fix #454

Switch `Execute` to `TryExecute`
Catch more exceptions explicitly in `ServiceCollector`