### PR TITLE
Cherry-pick #466 onto 2.2

### DIFF
--- a/Lib/Collectors/BaseCollector.cs
+++ b/Lib/Collectors/BaseCollector.cs
@@ -41,30 +41,30 @@ namespace AttackSurfaceAnalyzer.Collectors
             Stop();
         }
 
-        // Max number of elements to keep in Results if LowMemoryUsage mode is enabled.
-        public const int LOW_MEMORY_CUTOFF = 1000;
-
-        public void StallIfHighMemoryUsageAndLowMemoryModeEnabled()
-        {
-            if (opts.LowMemoryUsage)
-            {
-                int stallCount = 0;
-                while (Results.Count > LOW_MEMORY_CUTOFF)
-                {
-                    if (stallCount++ % 1000 == 0)
-                    {
-                        Log.Verbose("Stalling Collector with {0} results for Memory Usage", Results.Count);
-                    }
-                    Thread.Sleep(1);
-                }
-            }
-        }
-
         public abstract bool CanRunOnPlatform();
 
         public abstract void ExecuteInternal();
 
         private Stopwatch? watch;
+        private readonly Action<CollectObject>? changeHandler;
+
+        protected BaseCollector(CollectCommandOptions? opts, Action<CollectObject>? changeHandler)
+        {
+            this.opts = opts ?? new CollectCommandOptions();
+            this.changeHandler = changeHandler;
+        }
+
+        internal void HandleChange(CollectObject collectObject)
+        {
+            if (changeHandler != null)
+            {
+                changeHandler(collectObject);
+            }
+            else
+            {
+                Results.Push(collectObject);
+            }
+        }
 
         public RUN_STATUS RunStatus
         {

--- a/Lib/Collectors/CertificateCollector.cs
+++ b/Lib/Collectors/CertificateCollector.cs
@@ -16,7 +16,12 @@ namespace AttackSurfaceAnalyzer.Collectors
     /// </summary>
     public class CertificateCollector : BaseCollector
     {
-        public CertificateCollector(CollectCommandOptions? opts = null) => this.opts = opts ?? this.opts;
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="opts"></param>
+        /// <param name=""></param>
+        public CertificateCollector(CollectCommandOptions? opts = null, Action<CollectObject>? changeHandler = null) : base(opts, changeHandler) { }
 
         public override bool CanRunOnPlatform()
         {
@@ -43,7 +48,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                                 StoreLocation: storeLocation.ToString(),
                                 StoreName: storeName.ToString(),
                                 Certificate: new SerializableCertificate(certificate));
-                            Results.Push(obj);
+                            HandleChange(obj);
                         }
                         store.Close();
                     }
@@ -76,7 +81,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                                 StoreLocation: StoreLocation.LocalMachine.ToString(),
                                 StoreName: StoreName.Root.ToString(),
                                 Certificate: new SerializableCertificate(certificate));
-                            Results.Push(obj);
+                            HandleChange(obj);
                         }
                         catch (Exception e)
                         {
@@ -127,7 +132,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                                 StoreLocation: StoreLocation.LocalMachine.ToString(),
                                 StoreName: StoreName.Root.ToString(),
                                 Certificate: new SerializableCertificate(certificate));
-                            Results.Push(obj);
+                            HandleChange(obj);
                         }
                     }
                     else

--- a/Lib/Collectors/ComObjectCollector.cs
+++ b/Lib/Collectors/ComObjectCollector.cs
@@ -17,7 +17,7 @@ namespace AttackSurfaceAnalyzer.Collectors
     /// </summary>
     public class ComObjectCollector : BaseCollector
     {
-        public ComObjectCollector(CollectCommandOptions? opts = null) => this.opts = opts ?? this.opts;
+        public ComObjectCollector(CollectCommandOptions? opts = null, Action<CollectObject>? changeHandler = null) : base(opts, changeHandler) { }
 
         /// <summary>
         /// Com Objects only exist on Windows.
@@ -47,7 +47,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                 var CLDIDs = SearchKey.OpenSubKey("SOFTWARE\\Classes\\CLSID");
                 foreach (var comObj in ParseComObjects(CLDIDs, view, opts.SingleThread))
                 {
-                    Results.Push(comObj);
+                    HandleChange(comObj);
                 }
             }
             catch (Exception e) when (//lgtm [cs/empty-catch-block]
@@ -70,7 +70,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                         using var ComKey = SearchKey.OpenSubKey(subkeyName).OpenSubKey("CLSID");
                         foreach (var comObj in ParseComObjects(ComKey, view, opts.SingleThread))
                         {
-                            Results.Push(comObj);
+                            HandleChange(comObj);
                         }
                     }
                 }

--- a/Lib/Collectors/EventLogCollector.cs
+++ b/Lib/Collectors/EventLogCollector.cs
@@ -19,7 +19,7 @@ namespace AttackSurfaceAnalyzer.Collectors
     /// </summary>
     public class EventLogCollector : BaseCollector
     {
-        public EventLogCollector(CollectCommandOptions? opts = null) => this.opts = opts ?? this.opts;
+        public EventLogCollector(CollectCommandOptions? opts = null, Action<CollectObject>? changeHandler = null) : base(opts, changeHandler) { }
 
         public override void ExecuteInternal()
         {
@@ -73,8 +73,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                                     Timestamp = entry.TimeGenerated,
                                     Data = new List<string>() { entry.Message }
                                 };
-                                StallIfHighMemoryUsageAndLowMemoryModeEnabled();
-                                Results.Push(obj);
+                                HandleChange(obj);
                             }
                         }
                     }
@@ -116,8 +115,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                             {
                                 obj.Timestamp = Timestamp;
                             }
-                            StallIfHighMemoryUsageAndLowMemoryModeEnabled();
-                            Results.Push(obj);
+                            HandleChange(obj);
                         }
                     }
                 }
@@ -180,8 +178,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                     {
                         if (curObject != null)
                         {
-                            StallIfHighMemoryUsageAndLowMemoryModeEnabled();
-                            Results.Push(curObject);
+                            HandleChange(curObject);
                         }
 
                         curObject = new EventLogObject(evt)
@@ -210,8 +207,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                 process.WaitForExit();
                 if (curObject != null)
                 {
-                    StallIfHighMemoryUsageAndLowMemoryModeEnabled();
-                    Results.Push(curObject);
+                    HandleChange(curObject);
                 }
             }
             catch (Exception e)

--- a/Lib/Collectors/FirewallCollector.cs
+++ b/Lib/Collectors/FirewallCollector.cs
@@ -18,7 +18,7 @@ namespace AttackSurfaceAnalyzer.Collectors
     /// </summary>
     public class FirewallCollector : BaseCollector
     {
-        public FirewallCollector(CollectCommandOptions? opts = null) => this.opts = opts ?? this.opts;
+        public FirewallCollector(CollectCommandOptions? opts = null, Action<CollectObject>? changeHandler = null) : base(opts, changeHandler) { }
 
         public override bool CanRunOnPlatform()
         {
@@ -54,7 +54,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                         obj.LocalPorts = rule.LocalPorts.ToList().ConvertAll(port => port.ToString(CultureInfo.InvariantCulture));
                         obj.RemoteAddresses = rule.RemoteAddresses.ToList().ConvertAll(address => address.ToString());
                         obj.RemotePorts = rule.RemotePorts.ToList().ConvertAll(port => port.ToString(CultureInfo.InvariantCulture));
-                        Results.Push(obj);
+                        HandleChange(obj);
                     }
                     catch (Exception e)
                     {
@@ -101,7 +101,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                             obj.Direction = chainName.Equals("INPUT") ? FirewallDirection.Inbound : FirewallDirection.Outbound;
                         }
 
-                        Results.Push(obj);
+                        HandleChange(obj);
                     }
                     else if (line.StartsWith("-A"))
                     {
@@ -142,7 +142,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                             obj.Direction = chainName.Equals("INPUT") ? FirewallDirection.Inbound : FirewallDirection.Outbound;
                         }
 
-                        Results.Push(obj);
+                        HandleChange(obj);
                     }
                 }
             }
@@ -164,7 +164,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                 FriendlyName = "Firewall Enabled",
                 Scope = FirewallScope.All
             };
-            Results.Push(obj);
+            HandleChange(obj);
 
             // Example output: "Stealth mode disabled"
             result = ExternalCommandRunner.RunExternalCommand("/usr/libexec/ApplicationFirewall/socketfilterfw", "--getglobalstate");
@@ -176,7 +176,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                 FriendlyName = "Stealth Mode",
                 Scope = FirewallScope.All
             };
-            Results.Push(obj);
+            HandleChange(obj);
 
             /* Example Output:
              * Automatically allow signed built-in software ENABLED
@@ -190,7 +190,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                 FriendlyName = "Allow signed built-in software",
                 Scope = FirewallScope.All
             };
-            Results.Push(obj);
+            HandleChange(obj);
 
             obj = new FirewallObject("Allow downloaded signed software")
             {
@@ -200,7 +200,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                 FriendlyName = "Allow downloaded signed software",
                 Scope = FirewallScope.All
             };
-            Results.Push(obj);
+            HandleChange(obj);
 
             /* Example Output:
 ALF: total number of apps = 2 
@@ -232,7 +232,7 @@ ALF: total number of apps = 2
                             FriendlyName = appName,
                             Scope = FirewallScope.All
                         };
-                        Results.Push(obj);
+                        HandleChange(obj);
                     }
                 }
             }

--- a/Lib/Collectors/OpenPortCollector.cs
+++ b/Lib/Collectors/OpenPortCollector.cs
@@ -17,7 +17,7 @@ namespace AttackSurfaceAnalyzer.Collectors
     /// </summary>
     public class OpenPortCollector : BaseCollector
     {
-        public OpenPortCollector(CollectCommandOptions? opts = null) => this.opts = opts ?? this.opts;
+        public OpenPortCollector(CollectCommandOptions? opts = null, Action<CollectObject>? changeHandler = null) : base(opts, changeHandler) { }
 
         public override bool CanRunOnPlatform()
         {
@@ -75,7 +75,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                     obj.ProcessName = p.ProcessName;
                 }
 
-                Results.Push(obj);
+                HandleChange(obj);
             }
 
             foreach (var endpoint in properties.GetActiveUdpListeners())
@@ -87,7 +87,7 @@ namespace AttackSurfaceAnalyzer.Collectors
 
                 obj.ProcessName = Win32ProcessPorts.ProcessPortMap.Find(x => x.PortNumber == endpoint.Port)?.ProcessName;
 
-                Results.Push(obj);
+                HandleChange(obj);
             }
         }
 
@@ -128,7 +128,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                             {
                                 Address = address
                             };
-                            Results.Push(obj);
+                            HandleChange(obj);
                         }
 
                     }
@@ -194,7 +194,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                                 ProcessName = parts[0]
                             };
 
-                            Results.Push(obj);
+                            HandleChange(obj);
                         }
                     }
                 }

--- a/Lib/Collectors/RegistryCollector.cs
+++ b/Lib/Collectors/RegistryCollector.cs
@@ -26,7 +26,7 @@ namespace AttackSurfaceAnalyzer.Collectors
             (RegistryHive.ClassesRoot,string.Empty), (RegistryHive.CurrentConfig,string.Empty), (RegistryHive.CurrentUser,string.Empty), (RegistryHive.LocalMachine,string.Empty), (RegistryHive.Users,string.Empty)
         };
 
-        public RegistryCollector(CollectCommandOptions? opts = null)
+        public RegistryCollector(CollectCommandOptions? opts = null, Action<CollectObject>? changeHandler = null) : base(opts, changeHandler)
         {
             this.opts = opts ?? this.opts;
             Hives = DefaultHives;
@@ -67,7 +67,6 @@ namespace AttackSurfaceAnalyzer.Collectors
 
                 Action<RegistryHive, string, RegistryView> IterateOn = (registryHive, keyPath, registryView) =>
                 {
-                    StallIfHighMemoryUsageAndLowMemoryModeEnabled();
                     Log.Verbose("Beginning to parse {0}\\{1} in {2}", registryHive, keyPath, registryView);
                     RegistryObject? regObj = null;
                     try
@@ -82,7 +81,7 @@ namespace AttackSurfaceAnalyzer.Collectors
 
                     if (regObj != null)
                     {
-                        Results.Push(regObj);
+                        HandleChange(regObj);
                     }
                     Log.Verbose("Finished parsing {0}\\{1} in {1}", registryHive, keyPath, registryView);
                 };

--- a/Lib/Collectors/ServiceCollector.cs
+++ b/Lib/Collectors/ServiceCollector.cs
@@ -20,7 +20,7 @@ namespace AttackSurfaceAnalyzer.Collectors
     /// </summary>
     public class ServiceCollector : BaseCollector
     {
-        public ServiceCollector(CollectCommandOptions? opts = null) => this.opts = opts ?? this.opts;
+        public ServiceCollector(CollectCommandOptions? opts = null, Action<CollectObject>? changeHandler = null) : base(opts, changeHandler) { }
 
         /// <summary>
         /// Determines whether the ServiceCollector can run or not.
@@ -119,7 +119,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                     if (!string.IsNullOrEmpty(val))
                         obj.WaitHint = uint.Parse(val, CultureInfo.InvariantCulture);
 
-                    Results.Push(obj);
+                    HandleChange(obj);
                 }
             }
             catch (Exception e) when (
@@ -185,7 +185,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                     InstallDate = fso.Created
                 };
 
-                Results.Push(obj);
+                HandleChange(obj);
             }
         }
 
@@ -213,7 +213,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                             State = _fields[3],
                         };
 
-                        Results.Push(obj);
+                        HandleChange(obj);
                     }
                 }
             }
@@ -240,7 +240,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                         DisplayName = serviceName,
                     };
 
-                    Results.Push(obj);
+                    HandleChange(obj);
                 }
             }
             catch (ExternalException)
@@ -286,7 +286,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                     };
                     if (!outDict.ContainsKey(obj.Identity))
                     {
-                        Results.Push(obj);
+                        HandleChange(obj);
                         outDict.Add(obj.Identity, obj);
                     }
                 }

--- a/Lib/Collectors/UserAccountCollector.cs
+++ b/Lib/Collectors/UserAccountCollector.cs
@@ -20,7 +20,7 @@ namespace AttackSurfaceAnalyzer.Collectors
     /// </summary>
     public class UserAccountCollector : BaseCollector
     {
-        public UserAccountCollector(CollectCommandOptions? opts = null) => this.opts = opts ?? this.opts;
+        public UserAccountCollector(CollectCommandOptions? opts = null, Action<CollectObject>? changeHandler = null) : base(opts, changeHandler) { }
 
         public override bool CanRunOnPlatform()
         {
@@ -197,12 +197,12 @@ namespace AttackSurfaceAnalyzer.Collectors
 
             foreach (var user in users)
             {
-                Results.Push(user.Value);
+                HandleChange(user.Value);
             }
 
             foreach (var group in groups)
             {
-                Results.Push(group.Value);
+                HandleChange(group.Value);
             }
         }
 
@@ -310,11 +310,11 @@ namespace AttackSurfaceAnalyzer.Collectors
                         Groups[group].Users.Add(username);
                     }
                 }
-                Results.Push(accountDetails[username]);
+                HandleChange(accountDetails[username]);
             }
             foreach (var group in Groups)
             {
-                Results.Push(group.Value);
+                HandleChange(group.Value);
             }
         }
 
@@ -409,11 +409,11 @@ namespace AttackSurfaceAnalyzer.Collectors
                     }
                 }
                 accountDetails[username].Groups.AddRange(groups);
-                Results.Push(accountDetails[username]);
+                HandleChange(accountDetails[username]);
             }
             foreach (var group in Groups)
             {
-                Results.Push(group.Value);
+                HandleChange(group.Value);
             }
         }
     }

--- a/Lib/Objects/CommandOptions.cs
+++ b/Lib/Objects/CommandOptions.cs
@@ -158,8 +158,11 @@ namespace AttackSurfaceAnalyzer
         [Option('d', "directories", Required = false, HelpText = "Comma-separated list of directories to monitor.")]
         public string? MonitoredDirectories { get; set; }
 
-        [Option('i', "interrogate-file-changes", Required = false, HelpText = "On a file create or change gather the post-change file size and security attributes (Linux/Mac only)")]
-        public bool InterrogateChanges { get; set; }
+        [Option('a', "File names only", Required = false, HelpText = "Don't gather extended information. Overrides any argument to include additional data.")]
+        public bool FileNamesOnly { get; set; }
+
+        [Option('h', "gather-hashes", Required = false, HelpText = "Gather a hash of each file that is modified or created.")]
+        public bool GatherHashes { get; set; }
 
         //[Option('r', "registry", Required = false, HelpText = "Monitor the registry for changes. (Windows Only)")]
         //public bool EnableRegistryMonitor { get; set; }

--- a/Lib/Objects/FileMonitorObject.cs
+++ b/Lib/Objects/FileMonitorObject.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+using System.IO;
 using AttackSurfaceAnalyzer.Types;
 
 namespace AttackSurfaceAnalyzer.Objects
@@ -12,9 +13,10 @@ namespace AttackSurfaceAnalyzer.Objects
         public string? OldName { get; set; }
         public CHANGE_TYPE? ChangeType { get; set; }
         public string? ExtendedResults { get; set; }
-        public string? NotifyFilters { get; set; }
+        public NotifyFilters? NotifyFilters { get; set; }
         public string? Serialized { get; set; }
         public string? Timestamp { get; set; }
+        public FileSystemObject? FileSystemObject { get; set; }
 
         public override string Identity
         {

--- a/Tests/CollectorTests.cs
+++ b/Tests/CollectorTests.cs
@@ -7,6 +7,7 @@ using AttackSurfaceAnalyzer.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Win32;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -14,6 +15,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Threading;
 using WindowsFirewallHelper;
 
 namespace AttackSurfaceAnalyzer.Tests
@@ -67,6 +69,40 @@ namespace AttackSurfaceAnalyzer.Tests
 
             Assert.IsTrue(fsc.Results.Any(x => x is FileSystemObject FSO && FSO.Path.EndsWith("AsaLibTesterJavaClass") && FSO.IsExecutable == true));
             Assert.IsTrue(fsc.Results.Any(x => x is FileSystemObject FSO && FSO.Path.EndsWith("AsaLibTesterMZ") && FSO.IsExecutable == true));
+
+            ConcurrentStack<CollectObject> results = new ConcurrentStack<CollectObject>();
+            fsc = new FileSystemCollector(opts, x => results.Push(x));
+            fsc.TryExecute();
+
+            Assert.IsTrue(results.Any(x => x is FileSystemObject FSO && FSO.Path.EndsWith("AsaLibTesterJavaClass") && FSO.IsExecutable == true));
+            Assert.IsTrue(results.Any(x => x is FileSystemObject FSO && FSO.Path.EndsWith("AsaLibTesterMZ") && FSO.IsExecutable == true));
+        }
+
+        /// <summary>
+        /// Does not require admin
+        /// </summary>
+        [TestMethod]
+        public void TestFileMonitor()
+        {
+            var stack = new ConcurrentStack<FileMonitorObject>();
+            var monitor = new FileSystemMonitor(new MonitorCommandOptions() { MonitoredDirectories = Path.GetTempPath() }, x => stack.Push(x));
+            monitor.StartRun();
+
+            var created = Path.GetTempFileName(); // Create a file
+            var renamed = $"{created}-renamed";
+            File.WriteAllText(created, "Test"); // Change the size
+
+            File.Move(created, renamed); // Rename it
+            File.Delete(renamed); //Delete it
+
+            Thread.Sleep(1000);
+
+            monitor.StopRun();
+
+            Assert.IsTrue(stack.Any(x => x.NotifyFilters == NotifyFilters.FileName && x.Path == created));
+            Assert.IsTrue(stack.Any(x => x.NotifyFilters == NotifyFilters.Size && x.Path == created));
+            Assert.IsTrue(stack.Any(x => x.ChangeType == CHANGE_TYPE.RENAMED && x.NotifyFilters == NotifyFilters.FileName && x.Path == renamed));
+            Assert.IsTrue(stack.Any(x => x.ChangeType == CHANGE_TYPE.DELETED && x.Path == renamed));
         }
 
         /// <summary>
@@ -92,13 +128,19 @@ namespace AttackSurfaceAnalyzer.Tests
             eventLog.Source = "Attack Surface Analyzer Tests";
             eventLog.WriteEntry("This Log Entry was created for testing the Attack Surface Analyzer library.", EventLogEntryType.Warning, 101, 1);
 
-            var fsc = new EventLogCollector(new CollectCommandOptions());
-            fsc.TryExecute();
+            var elc = new EventLogCollector(new CollectCommandOptions());
+            elc.TryExecute();
+
+            Assert.IsTrue(elc.Results.Any(x => x is EventLogObject ELO && ELO.Source == "Attack Surface Analyzer Tests" && ELO.Timestamp is DateTime DT && DT.AddMinutes(1).CompareTo(DateTime.Now) > 0));
+
+            ConcurrentStack<CollectObject> results = new ConcurrentStack<CollectObject>();
+            elc = new EventLogCollector(new CollectCommandOptions(),x => results.Push(x));
+            elc.TryExecute();
+
+            Assert.IsTrue(results.Any(x => x is EventLogObject ELO && ELO.Source == "Attack Surface Analyzer Tests" && ELO.Timestamp is DateTime DT && DT.AddMinutes(1).CompareTo(DateTime.Now) > 0));
 
             EventLog.DeleteEventSource(source);
             EventLog.Delete(logname);
-
-            Assert.IsTrue(fsc.Results.Any(x => x is EventLogObject ELO && ELO.Source == "Attack Surface Analyzer Tests" && ELO.Timestamp is DateTime DT && DT.AddMinutes(1).CompareTo(DateTime.Now) > 0));
         }
 
         /// <summary>
@@ -107,10 +149,16 @@ namespace AttackSurfaceAnalyzer.Tests
         [TestMethod]
         public void TestCertificateCollectorWindows()
         {
-            var fsc = new CertificateCollector();
-            fsc.TryExecute();
+            var cc = new CertificateCollector();
+            cc.TryExecute();
 
-            Assert.IsTrue(fsc.Results.Where(x => x.ResultType == RESULT_TYPE.CERTIFICATE).Count() > 0);
+            Assert.IsTrue(cc.Results.Where(x => x.ResultType == RESULT_TYPE.CERTIFICATE).Count() > 0);
+
+            ConcurrentStack<CollectObject> results = new ConcurrentStack<CollectObject>();
+            cc = new CertificateCollector(changeHandler: x => results.Push(x));
+            cc.TryExecute();
+
+            Assert.IsTrue(results.Where(x => x.ResultType == RESULT_TYPE.CERTIFICATE).Count() > 0);
         }
 
         /// <summary>
@@ -136,11 +184,19 @@ namespace AttackSurfaceAnalyzer.Tests
             {
                 Console.WriteLine("Failed to open port.");
             }
-            var fsc = new OpenPortCollector();
-            fsc.TryExecute();
+            var pc = new OpenPortCollector();
+            pc.TryExecute();
+            var results1 = pc.Results;
+
+            ConcurrentStack<CollectObject> results = new ConcurrentStack<CollectObject>();
+            pc = new OpenPortCollector(changeHandler: x => results.Push(x));
+            pc.TryExecute();
+
             server.Stop();
 
-            Assert.IsTrue(fsc.Results.Any(x => x is OpenPortObject OPO && OPO.Port == 13000));
+            Assert.IsTrue(results1.Any(x => x is OpenPortObject OPO && OPO.Port == 13000));
+            Assert.IsTrue(results.Any(x => x is OpenPortObject OPO && OPO.Port == 13000));
+
         }
 
         /// <summary>
@@ -209,6 +265,12 @@ namespace AttackSurfaceAnalyzer.Tests
                 Assert.IsTrue(fwc.Results.Any(x => x is FirewallObject FWO && FWO.LocalPorts.Contains("9999")));
                 Assert.IsTrue(fwc.Results.Any(x => x is FirewallObject FWO && FWO.ApplicationName is string && FWO.ApplicationName.Equals(@"C:\MyApp.exe")));
 
+                ConcurrentStack<CollectObject> results = new ConcurrentStack<CollectObject>();
+                fwc = new FirewallCollector(changeHandler: x => results.Push(x));
+                fwc.TryExecute();
+
+                Assert.IsTrue(results.Any(x => x is FirewallObject FWO && FWO.LocalPorts.Contains("9999")));
+                Assert.IsTrue(results.Any(x => x is FirewallObject FWO && FWO.ApplicationName is string && FWO.ApplicationName.Equals(@"C:\MyApp.exe")));
 
                 var rules = FirewallManager.Instance.Rules.Where(r => r.Name == "TestFirewallPortRule");
                 foreach (var ruleIn in rules)
@@ -245,10 +307,17 @@ namespace AttackSurfaceAnalyzer.Tests
                 var rc = new RegistryCollector(new CollectCommandOptions() { SingleThread = true, SelectedHives = $"CurrentUser\\{name}" });
                 rc.TryExecute();
 
-                Registry.CurrentUser.DeleteSubKey(name);
-
                 Assert.IsTrue(rc.Results.Any(x => x is RegistryObject RO && RO.Key.EndsWith(name)));
                 Assert.IsTrue(rc.Results.Any(x => x is RegistryObject RO && RO.Key.EndsWith(name) && RO.Values.ContainsKey(value) && RO.Values[value] == value2));
+
+                ConcurrentStack<CollectObject> results = new ConcurrentStack<CollectObject>();
+                rc = new RegistryCollector(new CollectCommandOptions() { SingleThread = true, SelectedHives = $"CurrentUser\\{name}" }, x => results.Push(x));
+                rc.TryExecute();
+
+                Assert.IsTrue(results.Any(x => x is RegistryObject RO && RO.Key.EndsWith(name)));
+                Assert.IsTrue(results.Any(x => x is RegistryObject RO && RO.Key.EndsWith(name) && RO.Values.ContainsKey(value) && RO.Values[value] == value2));
+
+                Registry.CurrentUser.DeleteSubKey(name);
             }
         }
 
@@ -271,6 +340,12 @@ namespace AttackSurfaceAnalyzer.Tests
 
                 Assert.IsTrue(sc.Results.Any(x => x is ServiceObject RO && RO.Name.Equals(serviceName)));
 
+                ConcurrentStack<CollectObject> results = new ConcurrentStack<CollectObject>();
+                sc = new ServiceCollector(changeHandler: x => results.Push(x));
+                sc.TryExecute();
+
+                Assert.IsTrue(results.Any(x => x is ServiceObject RO && RO.Name.Equals(serviceName)));
+
                 // Clean up
                 cmd = string.Format("delete {0}", serviceName);
                 ExternalCommandRunner.RunExternalCommand("sc.exe", cmd);
@@ -289,6 +364,12 @@ namespace AttackSurfaceAnalyzer.Tests
                 coc.TryExecute();
 
                 Assert.IsTrue(coc.Results.Any(x => x is ComObject y && y.x86_Binary != null));
+
+                ConcurrentStack<CollectObject> results = new ConcurrentStack<CollectObject>();
+                coc = new ComObjectCollector(changeHandler: x => results.Push(x));
+                coc.TryExecute();
+
+                Assert.IsTrue(results.Any(x => x is ComObject y && y.x86_Binary != null));
             }
         }
 
@@ -311,6 +392,12 @@ namespace AttackSurfaceAnalyzer.Tests
                 uac.TryExecute();
 
                 Assert.IsTrue(uac.Results.Any(x => x is UserAccountObject y && y.Name.Equals(user)));
+
+                ConcurrentStack<CollectObject> results = new ConcurrentStack<CollectObject>();
+                uac = new UserAccountCollector(changeHandler: x => results.Push(x));
+                uac.TryExecute();
+
+                Assert.IsTrue(results.Any(x => x is UserAccountObject y && y.Name.Equals(user)));
 
                 cmd = string.Format("user /delete {0}", user);
                 ExternalCommandRunner.RunExternalCommand("net", cmd);


### PR DESCRIPTION
Improves FileSystemMonitor and adds new optional delegate version of collectors which removes the need to keep an internal queue in the Collector.  See wiki for updated usage details.