### PR TITLE
Switch to using ^ instead of , separated paths.

### DIFF
--- a/Lib/Collectors/FileSystemCollector.cs
+++ b/Lib/Collectors/FileSystemCollector.cs
@@ -20,6 +20,7 @@ using System.Security.Permissions;
 using System.Security.Principal;
 using System.Threading.Tasks;
 using Microsoft.CST.OpenSource.MultiExtractor;
+using Newtonsoft.Json;
 
 namespace AttackSurfaceAnalyzer.Collectors
 {
@@ -28,7 +29,7 @@ namespace AttackSurfaceAnalyzer.Collectors
     /// </summary>
     public class FileSystemCollector : BaseCollector
     {
-        public HashSet<string> Roots { get; } = new HashSet<string>();
+        public List<string> Roots { get; } = new List<string>();
 
         private readonly Dictionary<string, long> sizesOnDisk = new Dictionary<string, long>();
 
@@ -45,10 +46,7 @@ namespace AttackSurfaceAnalyzer.Collectors
         {
             if (!string.IsNullOrEmpty(opts.SelectedDirectories))
             {
-                foreach (string path in opts.SelectedDirectories.Split(','))
-                {
-                    Roots.Add(path);
-                }
+                Roots.AddRange(opts.SelectedDirectories.Split('^'));
             }
 
             if (!Roots.Any())
@@ -151,10 +149,10 @@ namespace AttackSurfaceAnalyzer.Collectors
                 Log.Verbose("Finished parsing {0}", Path);
             }
 
-            foreach (var root in Roots)
+            foreach (var Root in Roots)
             {
-                Log.Information("{0} root {1}", Strings.Get("Scanning"), root);
-                var directories = Directory.EnumerateDirectories(root, "*", new System.IO.EnumerationOptions()
+                Log.Information("{0} root {1}", Strings.Get("Scanning"), Root);
+                var directories = Directory.EnumerateDirectories(Root, "*", new System.IO.EnumerationOptions()
                 {
                     ReturnSpecialDirectories = false,
                     IgnoreInaccessible = true,
@@ -162,7 +160,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                 });
 
                 //First do root
-                TryIterateOnDirectory(root);
+                TryIterateOnDirectory(Root);
 
                 if (!opts.SingleThread == true)
                 {

--- a/Lib/Collectors/RegistryCollector.cs
+++ b/Lib/Collectors/RegistryCollector.cs
@@ -36,7 +36,7 @@ namespace AttackSurfaceAnalyzer.Collectors
                 if (opts.SelectedHives is string hiveString)
                 {
                     Hives = new List<(RegistryHive, string)>();
-                    var splits = hiveString.Split(',');
+                    var splits = hiveString.Split('^');
                     foreach (var split in splits)
                     {
                         var innerSplit = split.Split('\\');

--- a/Lib/Objects/CommandOptions.cs
+++ b/Lib/Objects/CommandOptions.cs
@@ -128,10 +128,10 @@ namespace AttackSurfaceAnalyzer
         [Option("crawl-archives", Required = false, HelpText = "Attempts to crawl every archive file encountered when using File Collector.  May dramatically increase run time of the scan.")]
         public bool CrawlArchives { get; set; }
 
-        [Option("directories", Required = false, HelpText = "Comma separated list of paths to scan with FileSystemCollector")]
+        [Option("directories", Required = false, HelpText = "^ separated list of paths to scan with FileSystemCollector")]
         public string? SelectedDirectories { get; set; }
 
-        [Option("hives", Required = false, HelpText = "Comma separated list of hives and subkeys to search.")]
+        [Option("hives", Required = false, HelpText = "^ separated list of hives and subkeys to search.")]
         public string? SelectedHives { get; set; }
 
         [Option(HelpText = "Download files from thin Cloud Folders (like OneDrive) to check them.")]


### PR DESCRIPTION
There seems to be a Windows 8 specific issue with CommandOptions that doesn't pass through comma separated values.

Fix #465