### PR TITLE
Fix File Locking when checking Executable status

### DIFF
--- a/Cli/Cli.csproj
+++ b/Cli/Cli.csproj
@@ -60,6 +60,10 @@
     <LaunchBrowser></LaunchBrowser>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'Gui' ">
+    <StartAction>Project</StartAction>
+    <LaunchBrowser></LaunchBrowser>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />

--- a/Lib/Collectors/FileSystemUtils.cs
+++ b/Lib/Collectors/FileSystemUtils.cs
@@ -189,7 +189,7 @@ namespace AttackSurfaceAnalyzer.Collectors
 
         public static EXECUTABLE_TYPE GetExecutableType(string Path)
         {
-            using var fs = new FileStream(Path, FileMode.Open);
+            using var fs = new FileStream(Path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             return GetExecutableType(Path, fs);
         }
 


### PR DESCRIPTION
In particular fixes FileSystemMonitor unintentionally locking files when detecting changes in them.