### PR TITLE
Gui Tweaks

### DIFF
--- a/Benchmarks/Benchmarks.csproj
+++ b/Benchmarks/Benchmarks.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Include="LiteDB" Version="5.0.11" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.114.4" />
     <PackageReference Include="murmurhash" Version="1.0.3" />

--- a/Cli/AppData.cs
+++ b/Cli/AppData.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
             }
         }
 
-        public enum ExclusiveMode
+        public enum Mode
         {
             None,
             Guided,
@@ -33,7 +33,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
             Scan
         }
 
-        public ExclusiveMode exclusiveMode { get; set; } = ExclusiveMode.None;
+        public Mode exclusiveMode { get; set; } = Mode.None;
 
         public enum ScanPageState
         {

--- a/Cli/AppData.cs
+++ b/Cli/AppData.cs
@@ -25,6 +25,52 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
             }
         }
 
+        public enum ExclusiveMode
+        {
+            None,
+            Guided,
+            Monitor,
+            Scan
+        }
+
+        public ExclusiveMode exclusiveMode { get; set; } = ExclusiveMode.None;
+
+        public enum ScanPageState
+        {
+            Options,
+            Scanning,
+            Finished,
+            Error,
+            Disabled
+        }
+
+        public ScanPageState scanPageState { get; set; } = ScanPageState.Options;
+
+        public enum GuidedPageState
+        {
+            Options,
+            Scanning,
+            Monitoring,
+            MonitorFlushing,
+            Analyzing,
+            Results,
+            Error,
+            Disabled
+        }
+        public MonitorPageState monitorPageState { get; set; } = MonitorPageState.Options;
+
+        public enum MonitorPageState
+        {
+            Options,
+            Monitoring,
+            MonitorFlushing,
+            Finished,
+            Error,
+            Disabled
+        }
+
+        public GuidedPageState guidedPageState { get; set; } = GuidedPageState.Options;
+
         public string MonitorRunId
         {
             get

--- a/Cli/AttackSurfaceAnalyzerClient.cs
+++ b/Cli/AttackSurfaceAnalyzerClient.cs
@@ -258,7 +258,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
             return AnalyzeMonitored(opts, analyzer, DatabaseManager.GetMonitorResults(opts.SecondRunId), opts.AnalysesFile ?? throw new ArgumentNullException(nameof(opts.AnalysesFile)));
         }
 
-        private static ConcurrentDictionary<(RESULT_TYPE, CHANGE_TYPE), List<CompareResult>> AnalyzeMonitored(CompareCommandOptions opts, AsaAnalyzer analyzer, IEnumerable<MonitorObject> collectObjects, RuleFile ruleFile)
+        public static ConcurrentDictionary<(RESULT_TYPE, CHANGE_TYPE), List<CompareResult>> AnalyzeMonitored(CompareCommandOptions opts, AsaAnalyzer analyzer, IEnumerable<MonitorObject> collectObjects, RuleFile ruleFile)
         {
             if (opts is null) { return new ConcurrentDictionary<(RESULT_TYPE, CHANGE_TYPE), List<CompareResult>>(); }
             var results = new ConcurrentDictionary<(RESULT_TYPE, CHANGE_TYPE), List<CompareResult>>();

--- a/Cli/Cli.csproj
+++ b/Cli/Cli.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.5" />
+    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.6" />
     <PackageReference Include="Tewr.Blazor.FileReader" Version="3.2.0.21211" />
   </ItemGroup>
 

--- a/Cli/Cli.csproj
+++ b/Cli/Cli.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.10" />
+    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.11" />
     <PackageReference Include="Tewr.Blazor.FileReader" Version="3.2.0.21211" />
   </ItemGroup>
 

--- a/Cli/Cli.csproj
+++ b/Cli/Cli.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.4" />
+    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.5" />
     <PackageReference Include="Tewr.Blazor.FileReader" Version="3.2.0.21211" />
   </ItemGroup>
 

--- a/Cli/Cli.csproj
+++ b/Cli/Cli.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.11" />
+    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.12" />
     <PackageReference Include="Tewr.Blazor.FileReader" Version="3.2.0.21211" />
   </ItemGroup>
 

--- a/Cli/Cli.csproj
+++ b/Cli/Cli.csproj
@@ -35,9 +35,9 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.10.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
-    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.4" />
     <PackageReference Include="Tewr.Blazor.FileReader" Version="3.2.0.21211" />
   </ItemGroup>
 

--- a/Cli/Cli.csproj
+++ b/Cli/Cli.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
-    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.3" />
     <PackageReference Include="Tewr.Blazor.FileReader" Version="3.2.0.21211" />
   </ItemGroup>
 

--- a/Cli/Cli.csproj
+++ b/Cli/Cli.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.6" />
+    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.9" />
     <PackageReference Include="Tewr.Blazor.FileReader" Version="3.2.0.21211" />
   </ItemGroup>
 

--- a/Cli/Cli.csproj
+++ b/Cli/Cli.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.9" />
+    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.10" />
     <PackageReference Include="Tewr.Blazor.FileReader" Version="3.2.0.21211" />
   </ItemGroup>
 

--- a/Cli/Cli.csproj
+++ b/Cli/Cli.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.12" />
+    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.1.13" />
     <PackageReference Include="Tewr.Blazor.FileReader" Version="3.2.0.21211" />
   </ItemGroup>
 

--- a/Cli/Components/AsaRuleInput.razor
+++ b/Cli/Components/AsaRuleInput.razor
@@ -32,7 +32,7 @@
                         <label for="ruleTarget">Target:</label>
                         @if (Types.Any())
                         {
-                            <TypesInput id="ruleTarget" Object="Rule" SubPath="Target" Types="Types" BindIndex="idx" /> 
+                            <TypesInput id="ruleTarget" Object="Rule" SubPath="Target" Types="Types" UseShortName="true" BindIndex="idx" /> 
                         }
                         else
                         {

--- a/Cli/Components/AsaRuleInput.razor
+++ b/Cli/Components/AsaRuleInput.razor
@@ -1,0 +1,114 @@
+﻿@using Microsoft.CST.OAT
+@using Microsoft.CST.OAT.Utils;
+@using System.Reflection;
+@using Microsoft.CST.OAT.Blazor.Components.Inputs;
+@switch (CollapsedState)
+{
+    case ComponentCollapsedState.Expanded:
+        <button class="card-top" type="button" @onclick="Collapse">
+            <span class="oi oi-chevron-top mx-3"></span>
+            <span>@Rule?.Name</span>
+        </button>
+        <div class="card-bottom">
+            <form class="mx-3 pt-2" onsubmit="return false;">
+                <div class="form-row">
+                    <div class="form-group col-6">
+                        <label for="ruleName">Name:</label>
+                        <StringInput id="ruleName" Object="Rule" SubPath="Name" placeholder="Name" />
+                    </div>
+                    <div class="form-group col-6">
+                        <label for="ruleDescription">Description:</label>
+                        <StringInput id="ruleDescription" Object="Rule" SubPath="Description" placeholder="Description" />
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label for="ruleExpression">Expression:</label>
+                    <StringInput id="ruleExpression" Object="Rule" SubPath="Expression" placeholder="Expression" />
+                </div>
+
+                <div class="form-row">
+                    <div class="form-group col-6">
+                        <label for="ruleTarget">Target:</label>
+                        @if (Types.Any())
+                        {
+                            <TypesInput id="ruleTarget" Object="Rule" SubPath="Target" Types="Types" BindIndex="idx" /> 
+                        }
+                        else
+                        {
+                            <StringInput id="ruleTarget" Object="Rule" SubPath="Target" placeholder="Target" />
+                        }
+                    </div>
+                    <div class="form-group col-6">
+                        <label for="ruleFLag">Flag:</label>
+                        <EnumInput id="ruleFlag" Object="Rule" Type="@typeof(ANALYSIS_RESULT_TYPE)" SubPath="Flag" />
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <button class="btn btn-secondary" @onclick="AddClause">Add Clause</button>
+                    <button class="btn btn-secondary" @onclick="RemoveLastClause" disabled="@HasNoClauses()">Remove Last Clause</button>
+                </div>
+
+                <div class="form-group">
+                    @for (var i = 0; i < Rule?.Clauses.Count; i++)
+                    {
+                        @if (Types.Any())
+                        {
+                            <ClauseInput Rule="@Rule" Clause="@i" Types="@Types" TypeIndex="@idx" /> 
+                        }
+                        else
+                        {
+                            <ClauseInput Rule="@Rule" Clause="@i" />                        
+                        }                    
+                    }
+                </div>
+            </form>
+        </div>        
+        break;
+
+    case ComponentCollapsedState.Collapsed:
+        <button class="card-top mb-2" type="button" @onclick="Expand">
+            <span class="oi oi-chevron-bottom mx-3"></span>
+            <span>@Rule?.Name</span>
+        </button>
+        break;
+}
+
+@code {
+    [Parameter]
+    public Type[] Types { get; set; } = Array.Empty<Type>();
+
+    IntHolder idx = new IntHolder();
+
+    void Expand(EventArgs eventArgs)
+    {
+        CollapsedState = ComponentCollapsedState.Expanded;
+    }
+
+    void Collapse(EventArgs eventArgs)
+    {
+        CollapsedState = ComponentCollapsedState.Collapsed;
+    }
+
+    bool HasNoClauses()
+    {
+        return Rule?.Clauses.Count == 0;
+    }
+
+    [Parameter]
+    public ComponentCollapsedState CollapsedState { get; set; } = ComponentCollapsedState.Collapsed;
+
+    [Parameter]
+    public AsaRule? Rule { get; set; }
+
+    void RemoveLastClause()
+    {
+        Rule?.Clauses.RemoveAt(Rule.Clauses.Count - 1);
+    }
+
+    void AddClause()
+    {
+        Rule?.Clauses.Add(new Clause(Operation.Regex));
+    }
+}

--- a/Cli/Components/CollectorOptions/FileCollectorOptions.razor
+++ b/Cli/Components/CollectorOptions/FileCollectorOptions.razor
@@ -24,10 +24,15 @@
         <div class="form-row">
             <div class="col-9 mb-1">
                 <select class="form-control @directorySelectElementGlowClass.ClassName" id="selectedDirectoriesList" @bind="SelectedDirectoryTop">
-                    @for (var i = 0; i < appData.CollectOptions.SelectedDirectories.Count(); i++)
+                    @if (appData.CollectOptions.SelectedDirectories.Any())
                     {
-                        <option value="@i">@appData.CollectOptions.SelectedDirectories.ToList()[i]</option>
+                        var list = appData.CollectOptions.SelectedDirectories.ToList();
+                        for (var i = 0; i < list.Count; i++)
+                        {
+                            <option value="@i">@list[i]</option>
+                        }
                     }
+                    
                 </select>
             </div>
             <div class="col">
@@ -76,6 +81,15 @@
             appData.CollectOptions.SelectedDirectories = appData.CollectOptions.SelectedDirectories.Except(appData.CollectOptions.SelectedDirectories.Skip(SelectedDirectoryTop-1).Take(1));
             Helper.ToggleGlow(() => InvokeAsync(StateHasChanged), directorySelectElementGlowClass, false);
         }
+    }
+
+    protected override void OnInitialized()
+    {
+        if (!appData.CollectOptions.SelectedDirectories.Any())
+        {
+            appData.CollectOptions.SelectedDirectories = FileSystemCollector.GetDefaultRoots();
+        }
+        base.OnInitialized();
     }
 
     void PushInputToList()

--- a/Cli/Components/CollectorOptions/FileCollectorOptions.razor
+++ b/Cli/Components/CollectorOptions/FileCollectorOptions.razor
@@ -79,7 +79,7 @@
 
     void RemoveInputFromList()
     {
-        if (selectedDirectories.Count > SelectedDirectoryTop)
+        if (selectedDirectories.Any() && selectedDirectories.Count > SelectedDirectoryTop)
         {
             selectedDirectories.RemoveAt(SelectedDirectoryTop);
             UpdateDirectories();

--- a/Cli/Components/CollectorOptions/FileCollectorOptions.razor
+++ b/Cli/Components/CollectorOptions/FileCollectorOptions.razor
@@ -24,13 +24,9 @@
         <div class="form-row">
             <div class="col-9 mb-1">
                 <select class="form-control @directorySelectElementGlowClass.ClassName" id="selectedDirectoriesList" @bind="SelectedDirectoryTop">
-                    @if (appData.CollectOptions.SelectedDirectories.Any())
+                    @for (var i = 0; i < selectedDirectories.Count; i++)
                     {
-                        var list = appData.CollectOptions.SelectedDirectories.ToList();
-                        for (var i = 0; i < list.Count; i++)
-                        {
-                            <option value="@i">@list[i]</option>
-                        }
+                        <option value="@i">@selectedDirectories[i]</option>
                     }
                     
                 </select>
@@ -74,11 +70,23 @@
     string SelectedDirectoryInput = string.Empty;
     int SelectedDirectoryTop;
 
+    List<string> selectedDirectories = new List<string>();
+
+    void UpdateDirectories()
+    {
+        appData.CollectOptions.SelectedDirectories = selectedDirectories;
+    }
+
     void RemoveInputFromList()
     {
-        if (appData.CollectOptions.SelectedDirectories.Count() > SelectedDirectoryTop)
+        if (selectedDirectories.Count > SelectedDirectoryTop)
         {
-            appData.CollectOptions.SelectedDirectories = appData.CollectOptions.SelectedDirectories.Except(appData.CollectOptions.SelectedDirectories.Skip(SelectedDirectoryTop-1).Take(1));
+            selectedDirectories.RemoveAt(SelectedDirectoryTop);
+            UpdateDirectories();
+            if (SelectedDirectoryTop >= selectedDirectories.Count)
+            {
+                SelectedDirectoryTop = selectedDirectories.Count - 1;
+            }
             Helper.ToggleGlow(() => InvokeAsync(StateHasChanged), directorySelectElementGlowClass, false);
         }
     }
@@ -87,16 +95,19 @@
     {
         if (!appData.CollectOptions.SelectedDirectories.Any())
         {
-            appData.CollectOptions.SelectedDirectories = FileSystemCollector.GetDefaultRoots();
+            selectedDirectories = FileSystemCollector.GetDefaultRoots().ToList();
+            UpdateDirectories();
         }
         base.OnInitialized();
     }
 
     void PushInputToList()
     {
-        appData.CollectOptions.SelectedDirectories = appData.CollectOptions.SelectedDirectories.Union(new string[] { SelectedDirectoryInput });
-        SelectedDirectoryTop = appData.CollectOptions.SelectedDirectories.Count() - 1;
-        Helper.ToggleGlow(() => InvokeAsync(StateHasChanged), directorySelectElementGlowClass, true);
+        selectedDirectories.Add(SelectedDirectoryInput);
+        SelectedDirectoryTop = selectedDirectories.Count - 1;
         SelectedDirectoryInput = string.Empty;
+
+        UpdateDirectories();
+        Helper.ToggleGlow(() => InvokeAsync(StateHasChanged), directorySelectElementGlowClass, true);
     }
 }

--- a/Cli/Components/CollectorOptions/RegistryCollectorOptions.razor
+++ b/Cli/Components/CollectorOptions/RegistryCollectorOptions.razor
@@ -55,7 +55,7 @@
 
     void RemoveInputFromList()
     {
-        if (selectedHives.Count > SelectedHiveTop)
+        if (selectedHives.Any() && selectedHives.Count > SelectedHiveTop)
         {
             selectedHives.RemoveAt(SelectedHiveTop);
             UpdateHives();

--- a/Cli/Components/CollectorOptions/RegistryCollectorOptions.razor
+++ b/Cli/Components/CollectorOptions/RegistryCollectorOptions.razor
@@ -46,25 +46,43 @@
     string SelectedHiveInput = string.Empty;
     int SelectedHiveTop;
 
+    List<string> selectedHives = new List<string>();
+
+    void UpdateHives()
+    {
+        appData.CollectOptions.SelectedHives = selectedHives;
+    }
+
     void RemoveInputFromList()
     {
-        appData.CollectOptions.SelectedHives = appData.CollectOptions.SelectedDirectories.Except(appData.CollectOptions.SelectedDirectories.Skip(SelectedHiveTop-1).Take(1));
-        Helper.ToggleGlow(() => InvokeAsync(StateHasChanged), directorySelectElementGlowClass, false);
+        if (selectedHives.Count > SelectedHiveTop)
+        {
+            selectedHives.RemoveAt(SelectedHiveTop);
+            UpdateHives();
+            if (selectedHives.Count <= SelectedHiveTop)
+            {
+                SelectedHiveTop = selectedHives.Count;
+            }
+            Helper.ToggleGlow(() => InvokeAsync(StateHasChanged), directorySelectElementGlowClass, false);
+        }
+
     }
 
     protected override void OnInitialized()
     {
         if (!appData.CollectOptions.SelectedHives.Any())
         {
-            appData.CollectOptions.SelectedHives = RegistryCollector.GetDefaultHives();
+            selectedHives = RegistryCollector.GetDefaultHives().ToList();
+            UpdateHives();
         }
         base.OnInitialized();
     }
 
     void PushInputToList()
     {
-        appData.CollectOptions.SelectedHives = appData.CollectOptions.SelectedHives.Union(new string[] { SelectedHiveInput });
-        SelectedHiveTop = appData.CollectOptions.SelectedHives.Count() - 1;
+        selectedHives.Add(SelectedHiveInput);
+        SelectedHiveTop = selectedHives.Count - 1;
+        UpdateHives();
         Helper.ToggleGlow(() => InvokeAsync(StateHasChanged), directorySelectElementGlowClass, true);
         SelectedHiveInput = string.Empty;
     }

--- a/Cli/Components/CollectorOptions/RegistryCollectorOptions.razor
+++ b/Cli/Components/CollectorOptions/RegistryCollectorOptions.razor
@@ -23,9 +23,13 @@
         <div class="form-row">
             <div class="col-9 mb-1">
                 <select class="form-control @directorySelectElementGlowClass.ClassName" id="selectedPathsList" @bind="SelectedHiveTop">
-                    @for (var i = 0; i < appData.CollectOptions.SelectedHives.Count(); i++)
+                    @if (appData.CollectOptions.SelectedHives.Any())
                     {
-                        <option value="@i">@appData.CollectOptions.SelectedHives.ToList()[i]</option>
+                        var hiveList = appData.CollectOptions.SelectedHives.ToList();
+                        for (var i = 0; i < hiveList.Count(); i++)
+                        {
+                            <option value="@i">@hiveList[i]</option>
+                        }
                     }
                 </select>
             </div>
@@ -46,6 +50,15 @@
     {
         appData.CollectOptions.SelectedHives = appData.CollectOptions.SelectedDirectories.Except(appData.CollectOptions.SelectedDirectories.Skip(SelectedHiveTop-1).Take(1));
         Helper.ToggleGlow(() => InvokeAsync(StateHasChanged), directorySelectElementGlowClass, false);
+    }
+
+    protected override void OnInitialized()
+    {
+        if (!appData.CollectOptions.SelectedHives.Any())
+        {
+            appData.CollectOptions.SelectedHives = RegistryCollector.GetDefaultHives();
+        }
+        base.OnInitialized();
     }
 
     void PushInputToList()

--- a/Cli/Components/MonitorOptions/FileMonitorOptions.razor
+++ b/Cli/Components/MonitorOptions/FileMonitorOptions.razor
@@ -30,9 +30,9 @@
         <div class="form-row">
             <div class="col-9 mb-1">
                 <select class="form-control @directorySelectElementGlowClass.ClassName" id="selectedDirectoriesList" @bind="SelectedDirectoryTop">
-                    @for (var i = 0; i < appData.MonitorOptions.MonitoredDirectories.Count(); i++)
+                    @for (var i = 0; i < selectedDirectories.Count(); i++)
                     {
-                        <option value="@i">@appData.MonitorOptions.MonitoredDirectories.ToList()[i]</option>
+                        <option value="@i">@selectedDirectories[i]</option>
                     }
                 </select>
             </div>
@@ -46,20 +46,47 @@
 @code{
     Helper.GlowClass directorySelectElementGlowClass = new Helper.GlowClass();
 
-    string SelectedDirectoryInput = string.Empty;
-    int SelectedDirectoryTop;
+    List<string> selectedDirectories = new List<string>();
+
+    void UpdateDirectories()
+    {
+        appData.MonitorOptions.MonitoredDirectories = selectedDirectories;
+    }
 
     void RemoveInputFromList()
     {
-        appData.MonitorOptions.MonitoredDirectories = appData.MonitorOptions.MonitoredDirectories.Except(appData.MonitorOptions.MonitoredDirectories.Skip(SelectedDirectoryTop-1).Take(1));
-        Helper.ToggleGlow(() => InvokeAsync(StateHasChanged), directorySelectElementGlowClass, false);
+        if (selectedDirectories.Any() && selectedDirectories.Count > SelectedDirectoryTop)
+        {
+            selectedDirectories.RemoveAt(SelectedDirectoryTop);
+            UpdateDirectories();
+            if (SelectedDirectoryTop >= selectedDirectories.Count)
+            {
+                SelectedDirectoryTop = selectedDirectories.Count - 1;
+            }
+            Helper.ToggleGlow(() => InvokeAsync(StateHasChanged), directorySelectElementGlowClass, false);
+        }
     }
 
     void PushInputToList()
     {
-        appData.MonitorOptions.MonitoredDirectories = appData.MonitorOptions.MonitoredDirectories.Union(new string[] { SelectedDirectoryInput });
-        SelectedDirectoryTop = appData.MonitorOptions.MonitoredDirectories.Count() - 1;
-        Helper.ToggleGlow(() => InvokeAsync(StateHasChanged), directorySelectElementGlowClass, true);
+        selectedDirectories.Add(SelectedDirectoryInput);
+        SelectedDirectoryTop = selectedDirectories.Count - 1;
         SelectedDirectoryInput = string.Empty;
+
+        UpdateDirectories();
+        Helper.ToggleGlow(() => InvokeAsync(StateHasChanged), directorySelectElementGlowClass, true);
+    }
+
+    string SelectedDirectoryInput = string.Empty;
+    int SelectedDirectoryTop;
+
+    protected override void OnInitialized()
+    {
+        if (!appData.MonitorOptions.MonitoredDirectories.Any())
+        {
+            selectedDirectories = FileSystemCollector.GetDefaultRoots().ToList();
+            UpdateDirectories();
+        }
+        base.OnInitialized();
     }
 }

--- a/Cli/Components/States/Results.razor
+++ b/Cli/Components/States/Results.razor
@@ -6,6 +6,11 @@
 @inject Microsoft.CST.AttackSurfaceAnalyzer.Cli.AppData appData
 
 <div class="form-inline pb-3">
+    <label class="mr-2" for="ExportPath">Export Path:</label>
+    <input id="ExportPath" type="text" placeholder="Current Directory" @bind="ExportPath" />
+    <button @onclick="ExportToFile">Export</button>
+</div>
+<div class="form-inline pb-3">
     <label class="mr-2" for="ResultType">Result Type:</label>
     <select class="form-control mr-2" id="ResultType" @bind="SelectedResultType">
         @foreach (var resultType in foundResultTypes)
@@ -208,21 +213,20 @@ else
                 }
             }
         }
-        var analysesHash = results.First(x => x.Value.Any()).Value.First().AnalysesHash;
         if (!string.IsNullOrEmpty(GuidedRunId))
         {
-            var guidedOpts = new ExportGuidedCommandOptions() { RunId = GuidedRunId, OutputPath = ExportPath };
-            AttackSurfaceAnalyzerClient.ExportGuidedModeResults(results, guidedOpts, analysesHash);
+            var guidedOpts = new ExportGuidedCommandOptions() { RunId = GuidedRunId, OutputPath = ExportPath, ApplySubObjectRulesToMonitor = true };
+            AttackSurfaceAnalyzerClient.ExportGuidedModeResults(results, guidedOpts, AnalysesHash);
         }
         else if (!string.IsNullOrEmpty(MonitorRunId))
         {
-            var monitorOpts = new ExportMonitorCommandOptions() { RunId = MonitorRunId, OutputPath = ExportPath };
-            AttackSurfaceAnalyzerClient.ExportCompareResults(results, monitorOpts, MonitorRunId, analysesHash);
+            var monitorOpts = new ExportMonitorCommandOptions() { RunId = MonitorRunId, OutputPath = ExportPath, ApplySubObjectRulesToMonitor = true };
+            AttackSurfaceAnalyzerClient.ExportCompareResults(results, monitorOpts, MonitorRunId, AnalysesHash);
         }
         else
         {
             var scanOpts = new ExportCollectCommandOptions() { FirstRunId = FirstRunId, SecondRunId = SecondRunId, OutputPath = ExportPath };
-            AttackSurfaceAnalyzerClient.ExportCompareResults(results, scanOpts, $"{FirstRunId} vs {SecondRunId}", analysesHash);
+            AttackSurfaceAnalyzerClient.ExportCompareResults(results, scanOpts, $"{FirstRunId} vs {SecondRunId}", AnalysesHash);
         }
     }
 

--- a/Cli/Components/States/Results.razor
+++ b/Cli/Components/States/Results.razor
@@ -1,5 +1,8 @@
 ﻿@using Microsoft.CST.AttackSurfaceAnalyzer.Types
 @using Microsoft.CST.AttackSurfaceAnalyzer.Objects
+@using System.IO
+@using System.Collections.Concurrent
+@using static Microsoft.CST.AttackSurfaceAnalyzer.Cli.AppData
 @inject Microsoft.CST.AttackSurfaceAnalyzer.Cli.AppData appData
 
 <div class="form-inline pb-3">
@@ -80,6 +83,8 @@ else
     public string AnalysesHash { get { return _analysesHash; } set { _analysesHash = value; OnInitialized(); } }
     [Parameter]
     public string MonitorRunId { get { return _monitorRunId; } set { _monitorRunId = value; OnInitialized(); } }
+    [Parameter]
+    public string GuidedRunId { get; set; } = string.Empty;
 
     protected override void OnInitialized()
     {
@@ -107,6 +112,7 @@ else
         }
     }
 
+    string ExportPath = Directory.GetCurrentDirectory();
     string _selectedResultType = "FILEMONITOR";
     string SelectedResultType
     {
@@ -165,6 +171,58 @@ else
             default:
                 analysisResults = AttackSurfaceAnalyzerClient.DatabaseManager.GetComparisonResults(FirstRunId, SecondRunId, AnalysesHash, resultType, offset, MaxResults);
                 break;
+        }
+    }
+
+    public void ExportToFile()
+    {
+        if (AttackSurfaceAnalyzerClient.DatabaseManager is null) { return; }
+        var iterationSize = 1000;
+        var results = new ConcurrentDictionary<(RESULT_TYPE, CHANGE_TYPE), List<CompareResult>>();
+        foreach(var resultType in foundResultTypes)
+        {
+            for (int i = 0; i < resultType.Value; i += iterationSize)
+            {
+                switch (resultType.Key)
+                {
+                    case RESULT_TYPE.FILEMONITOR:
+                        foreach(var result in AttackSurfaceAnalyzerClient.DatabaseManager.GetComparisonResults(string.Empty, MonitorRunId, AnalysesHash, resultType.Key, i, iterationSize))
+                        {
+                            if (!results.ContainsKey((result.ResultType, result.ChangeType)))
+                            {
+                                results[(result.ResultType, result.ChangeType)] = new List<CompareResult>();
+                            }
+                            results[(result.ResultType, result.ChangeType)].Add(result);
+                        }
+                        break;
+                    default:
+                        foreach(var result in AttackSurfaceAnalyzerClient.DatabaseManager.GetComparisonResults(FirstRunId, SecondRunId, AnalysesHash, resultType.Key, i, iterationSize))
+                        {
+                            if (!results.ContainsKey((result.ResultType, result.ChangeType)))
+                            {
+                                results[(result.ResultType, result.ChangeType)] = new List<CompareResult>();
+                            }
+                            results[(result.ResultType, result.ChangeType)].Add(result);
+                        }
+                        break;
+                }
+            }
+        }
+        var analysesHash = results.First(x => x.Value.Any()).Value.First().AnalysesHash;
+        if (!string.IsNullOrEmpty(GuidedRunId))
+        {
+            var guidedOpts = new ExportGuidedCommandOptions() { RunId = GuidedRunId, OutputPath = ExportPath };
+            AttackSurfaceAnalyzerClient.ExportGuidedModeResults(results, guidedOpts, analysesHash);
+        }
+        else if (!string.IsNullOrEmpty(MonitorRunId))
+        {
+            var monitorOpts = new ExportMonitorCommandOptions() { RunId = MonitorRunId, OutputPath = ExportPath };
+            AttackSurfaceAnalyzerClient.ExportCompareResults(results, monitorOpts, MonitorRunId, analysesHash);
+        }
+        else
+        {
+            var scanOpts = new ExportCollectCommandOptions() { FirstRunId = FirstRunId, SecondRunId = SecondRunId, OutputPath = ExportPath };
+            AttackSurfaceAnalyzerClient.ExportCompareResults(results, scanOpts, $"{FirstRunId} vs {SecondRunId}", analysesHash);
         }
     }
 

--- a/Cli/Components/States/Results.razor
+++ b/Cli/Components/States/Results.razor
@@ -2,6 +2,7 @@
 @using Microsoft.CST.AttackSurfaceAnalyzer.Objects
 @using System.IO
 @using System.Collections.Concurrent
+@using Microsoft.CST.OAT.Blazor.Components.Inputs
 @using static Microsoft.CST.AttackSurfaceAnalyzer.Cli.AppData
 @inject Microsoft.CST.AttackSurfaceAnalyzer.Cli.AppData appData
 
@@ -57,6 +58,7 @@
     {
         var result = analysisResults[i];
         var resultNumber = offset + i + 1;
+        var collapseNumber = i;
         <div class="pb-3">
             <div>
                 <span class="result-number">@resultNumber. </span>
@@ -65,6 +67,21 @@
             @foreach (var rule in result.Rules)
             {
                 <div class="rule-text">@rule.Name: @rule.Description</div>
+            }
+            @if (collapsedStates[i] == CollapsedState.Collapsed)
+            {
+                <button class="btn btn-primary" type="button" @onclick="() => { collapsedStates[collapseNumber] = CollapsedState.Expanded; }">
+                    <span class="oi oi-chevron-bottom mx-3"></span>
+                    <span>Expand</span>
+                </button>
+            }
+            else
+            {
+                <button class="btn btn-primary" type="button" @onclick="() => {collapsedStates[collapseNumber] = CollapsedState.Collapsed;}">
+                    <span class="oi oi-chevron-top mx-3"></span>
+                    <span>Collapse</span>
+                </button>
+                <PropertyInput id="@resultNumber.ToString()" Object="@analysisResults" SubPath="@collapseNumber.ToString()" isDisabled="true" type="typeof(CompareResult)" onChangeAction="this.StateHasChanged"/>
             }
         </div>
     }
@@ -90,6 +107,14 @@ else
     public string MonitorRunId { get { return _monitorRunId; } set { _monitorRunId = value; OnInitialized(); } }
     [Parameter]
     public string GuidedRunId { get; set; } = string.Empty;
+
+    enum CollapsedState
+    {
+        Collapsed,
+        Expanded
+    };
+
+    List<CollapsedState> collapsedStates = new List<CollapsedState>();
 
     protected override void OnInitialized()
     {
@@ -177,6 +202,7 @@ else
                 analysisResults = AttackSurfaceAnalyzerClient.DatabaseManager.GetComparisonResults(FirstRunId, SecondRunId, AnalysesHash, resultType, offset, MaxResults);
                 break;
         }
+        collapsedStates = analysisResults.Select(_ => CollapsedState.Collapsed).ToList();
     }
 
     public void ExportToFile()

--- a/Cli/Components/States/Results.razor
+++ b/Cli/Components/States/Results.razor
@@ -58,7 +58,6 @@
     {
         var result = analysisResults[i];
         var resultNumber = offset + i + 1;
-        var collapseNumber = i;
         <div class="pb-3">
             <div>
                 <span class="result-number">@resultNumber. </span>
@@ -68,21 +67,7 @@
             {
                 <div class="rule-text">@rule.Name: @rule.Description</div>
             }
-            @if (collapsedStates[i] == CollapsedState.Collapsed)
-            {
-                <button class="btn btn-primary" type="button" @onclick="() => { collapsedStates[collapseNumber] = CollapsedState.Expanded; }">
-                    <span class="oi oi-chevron-bottom mx-3"></span>
-                    <span>Expand</span>
-                </button>
-            }
-            else
-            {
-                <button class="btn btn-primary" type="button" @onclick="() => {collapsedStates[collapseNumber] = CollapsedState.Collapsed;}">
-                    <span class="oi oi-chevron-top mx-3"></span>
-                    <span>Collapse</span>
-                </button>
-                <PropertyInput id="@resultNumber.ToString()" Object="@analysisResults" SubPath="@collapseNumber.ToString()" isDisabled="true" type="typeof(CompareResult)" onChangeAction="this.StateHasChanged"/>
-            }
+            <ObjectInput id="@resultNumber.ToString()" Object="@analysisResults" SubPath="@i.ToString()" isDisabled="true" Collapsable="true" onChangeAction="this.StateHasChanged"/>
         </div>
     }
 }

--- a/Cli/Components/States/Scanning.razor
+++ b/Cli/Components/States/Scanning.razor
@@ -9,7 +9,7 @@
 @code{
     List<BaseCollector> collectors = AttackSurfaceAnalyzerClient.GetCollectors();
 
-    Timer timer;
+    Timer timer = new Timer((_) => { });
 
     string RunStatusToString(RUN_STATUS runStatus) => runStatus switch
     {

--- a/Cli/Components/States/Scanning.razor
+++ b/Cli/Components/States/Scanning.razor
@@ -17,7 +17,7 @@
         RUN_STATUS.FAILED => "Failed",
         RUN_STATUS.NOT_STARTED => "Not Started",
         RUN_STATUS.NO_RESULTS => "No Results",
-        RUN_STATUS.RUNNING => "Running"
+        RUN_STATUS.RUNNING => "Running",
         _ => "Unknown"
     };
 

--- a/Cli/Components/States/Scanning.razor
+++ b/Cli/Components/States/Scanning.razor
@@ -1,7 +1,20 @@
 ﻿@using Microsoft.CST.AttackSurfaceAnalyzer.Collectors 
 <p>Running Scan...</p>
 <div class="spinner-border text-primary"></div>
-@foreach (BaseCollector collector in AttackSurfaceAnalyzerClient.GetCollectors())
+@foreach (BaseCollector collector in collectors)
 {
     <div>@collector.GetType().ToString(): @collector.RunStatus</div>
+}
+
+@code{
+    List<BaseCollector> collectors = AttackSurfaceAnalyzerClient.GetCollectors();
+
+    Timer timer;
+
+    protected override void OnInitialized()
+    {
+        timer = new System.Threading.Timer((_) => InvokeAsync(() => StateHasChanged()), null, 0, 100);
+        base.OnInitialized();
+    }
+
 }

--- a/Cli/Components/States/Scanning.razor
+++ b/Cli/Components/States/Scanning.razor
@@ -9,7 +9,7 @@
 @code{
     List<BaseCollector> collectors = AttackSurfaceAnalyzerClient.GetCollectors();
 
-    Timer timer = new Timer((_) => { });
+    Timer? timer;
 
     string RunStatusToString(RUN_STATUS runStatus) => runStatus switch
     {

--- a/Cli/Components/States/Scanning.razor
+++ b/Cli/Components/States/Scanning.razor
@@ -3,13 +3,23 @@
 <div class="spinner-border text-primary"></div>
 @foreach (BaseCollector collector in collectors)
 {
-    <div>@collector.GetType().ToString(): @collector.RunStatus</div>
+    <div>@collector.GetType().Name: @RunStatusToString(collector.RunStatus)</div>
 }
 
 @code{
     List<BaseCollector> collectors = AttackSurfaceAnalyzerClient.GetCollectors();
 
     Timer timer;
+
+    string RunStatusToString(RUN_STATUS runStatus) => runStatus switch
+    {
+        RUN_STATUS.COMPLETED => "Completed",
+        RUN_STATUS.FAILED => "Failed",
+        RUN_STATUS.NOT_STARTED => "Not Started",
+        RUN_STATUS.NO_RESULTS => "No Results",
+        RUN_STATUS.RUNNING => "Running"
+        _ => "Unknown"
+    };
 
     protected override void OnInitialized()
     {

--- a/Cli/Pages/Analyze.razor
+++ b/Cli/Pages/Analyze.razor
@@ -1,4 +1,5 @@
 ﻿@page "/analyze"
+@using System.IO
 
 <h4>Analyze</h4>
 <div class="container-fluid bg-custom my-1 pb-1">
@@ -23,6 +24,8 @@
                             <option value="@i">@Runs[i]</option>
                         }
                     </select>
+                    <label for="CustomRulesPath">Custom Rules Path (optional):</label>
+                    <input id="CustomRulesPath" type="text" placeholder="Custom Rules Path" @bind="appData.ExportCollectCommandOptions.AnalysesFile" />
                     <button class="btn btn-primary" @onclick="BeginAnalyze">Start Analysis Scan</button>
                 </div>
             </div>
@@ -109,6 +112,7 @@
 
         appData.ExportCollectCommandOptions.FirstRunId = string.IsNullOrEmpty(secondRunId) ? secondRunId : firstRunId;
         appData.ExportCollectCommandOptions.SecondRunId = string.IsNullOrEmpty(secondRunId) ? firstRunId : secondRunId;
+
         pageState = PageState.Analyzing;
 
         await Task.Factory.StartNew(() =>

--- a/Cli/Pages/Author.razor
+++ b/Cli/Pages/Author.razor
@@ -50,7 +50,7 @@
                 <p>Processing Issues for Rule...</p>
             }
 
-            <RuleInput Rule="rule" CollapsedState="ComponentCollapsedState.Collapsed" Types="Types" />
+            <AsaRuleInput Rule="rule" CollapsedState="ComponentCollapsedState.Collapsed" Types="Types" />
         </div>
     }
 </div>

--- a/Cli/Pages/Guided.razor
+++ b/Cli/Pages/Guided.razor
@@ -162,7 +162,7 @@
         ResetExclusive();
     }
 
-    System.Threading.Timer timer = new Timer((_) => { });
+    System.Threading.Timer? timer;
 
     async Task<ASA_ERROR> BeginScan()
     {

--- a/Cli/Pages/Guided.razor
+++ b/Cli/Pages/Guided.razor
@@ -162,7 +162,7 @@
         ResetExclusive();
     }
 
-    System.Threading.Timer timer = new Timer((_) => { }, null, int.MaxValue, Timeout.Infinite);
+    System.Threading.Timer timer = new Timer((_) => { });
 
     async Task<ASA_ERROR> BeginScan()
     {

--- a/Cli/Pages/Guided.razor
+++ b/Cli/Pages/Guided.razor
@@ -10,11 +10,11 @@
 
 <h4>Guided Mode</h4>
 <div class="container-fluid bg-custom my-1 pb-1">
-    @if (appData.exclusiveMode == ExclusiveMode.Scan)
+    @if (appData.exclusiveMode == Mode.Scan)
     {
         <p>You cannot start a guided mode scan while scanning. Complete your existing scan first.</p>
     }
-    else if (appData.exclusiveMode == ExclusiveMode.Monitor)
+    else if (appData.exclusiveMode == Mode.Monitor)
     {
         <p>You cannot start a guided mode scan while monitoring. Complete your monitoring first.</p>
     }
@@ -72,7 +72,7 @@
                 break;
             case GuidedPageState.Results:
                 <button class="btn btn-primary" @onclick="Reset">Start Again</button>
-                <Results FirstRunId="@appData.ExportCollectCommandOptions.FirstRunId" SecondRunId="@appData.ExportCollectCommandOptions.SecondRunId" AnalysesHash="@appData.CompareCommandOptions.AnalysesFile?.GetHash()" MonitorRunId="@appData.MonitorOptions.RunId" />
+                <Results GuidedRunId="@RunIdInput" FirstRunId="@appData.ExportCollectCommandOptions.FirstRunId" SecondRunId="@appData.ExportCollectCommandOptions.SecondRunId" AnalysesHash="@appData.CompareCommandOptions.AnalysesFile?.GetHash()" MonitorRunId="@appData.MonitorOptions.RunId" />
                 break;
             case GuidedPageState.Error:
                 <p>An Error Occured while collecting.</p>
@@ -100,9 +100,9 @@
 
     bool TrySetExclusive()
     {
-        if (appData.exclusiveMode == ExclusiveMode.None)
+        if (appData.exclusiveMode == Mode.None)
         {
-            appData.exclusiveMode = ExclusiveMode.Guided;
+            appData.exclusiveMode = Mode.Guided;
             return true;
         }
         return false;
@@ -110,9 +110,9 @@
 
     void ResetExclusive()
     {
-        if (appData.exclusiveMode == ExclusiveMode.Guided)
+        if (appData.exclusiveMode == Mode.Guided)
         {
-            appData.exclusiveMode = ExclusiveMode.None;
+            appData.exclusiveMode = Mode.None;
         }
     }
 
@@ -132,7 +132,7 @@
             else
             {
                 appData.guidedPageState = GuidedPageState.Error;
-                appData.exclusiveMode = ExclusiveMode.None;
+                appData.exclusiveMode = Mode.None;
             }        
         }
         else

--- a/Cli/Pages/Guided.razor
+++ b/Cli/Pages/Guided.razor
@@ -72,7 +72,7 @@
                 break;
             case GuidedPageState.Results:
                 <button class="btn btn-primary" @onclick="Reset">Start Again</button>
-                <Results GuidedRunId="@RunIdInput" FirstRunId="@appData.ExportCollectCommandOptions.FirstRunId" SecondRunId="@appData.ExportCollectCommandOptions.SecondRunId" AnalysesHash="@appData.CompareCommandOptions.AnalysesFile?.GetHash()" MonitorRunId="@appData.MonitorOptions.RunId" />
+                <Results GuidedRunId="@appData.RunId" FirstRunId="@appData.ExportCollectCommandOptions.FirstRunId" SecondRunId="@appData.ExportCollectCommandOptions.SecondRunId" AnalysesHash="@appData.CompareCommandOptions.AnalysesFile?.GetHash()" MonitorRunId="@appData.MonitorOptions.RunId" />
                 break;
             case GuidedPageState.Error:
                 <p>An Error Occured while collecting.</p>

--- a/Cli/Pages/Guided.razor
+++ b/Cli/Pages/Guided.razor
@@ -3,110 +3,149 @@
 @using System.Threading;
 @using Microsoft.CST.AttackSurfaceAnalyzer.Objects
 @using Microsoft.CST.AttackSurfaceAnalyzer.Collectors
+@using static Microsoft.CST.AttackSurfaceAnalyzer.Cli.AppData
 @inject Microsoft.CST.AttackSurfaceAnalyzer.Cli.AppData appData
 
 @page "/guided"
 
 <h4>Guided Mode</h4>
 <div class="container-fluid bg-custom my-1 pb-1">
-    @switch (pageState)
+    @if (appData.exclusiveMode == ExclusiveMode.Scan)
     {
-        case PageState.Options:
-            <div class="run-box bg-custom">
-                <div class="form-inline">
-                    <label class="mr-2" for="RunId">Run ID:</label>
-                    <input type="text" class="form-control mr-2" id="RunId" placeholder="Enter Run ID" @bind="RunIdInput" />
-                    <div class="form-check mr-2">
-                        <input type="checkbox" class="form-check-input" id="UseTimestampCheckbox" @bind="UseTimestamp" />
-                        <label class="form-check-label" for="UseTimestampCheckbox">Use Timestamp</label>
+        <p>You cannot start a guided mode scan while scanning. Complete your existing scan first.</p>
+    }
+    else if (appData.exclusiveMode == ExclusiveMode.Monitor)
+    {
+        <p>You cannot start a guided mode scan while monitoring. Complete your monitoring first.</p>
+    }
+    else
+    {
+        @switch (appData.guidedPageState)
+        {
+            case GuidedPageState.Options:
+                <div class="run-box bg-custom">
+                    <div class="form-inline">
+                        <label class="mr-2" for="RunId">Run ID:</label>
+                        <input type="text" class="form-control mr-2" id="RunId" placeholder="@GetPlaceholder()" @bind="RunIdInput" disabled="@UseTimestamp" />
+                        <div class="form-check mr-2">
+                            <input type="checkbox" class="form-check-input" id="UseTimestampCheckbox" @bind="UseTimestamp" />
+                            <label class="form-check-label" for="UseTimestampCheckbox">Use Timestamp</label>
+                        </div>
+                        <button class="btn btn-primary" @onclick="BeginGuided">Start Guided Scan</button>
                     </div>
-                    <button class="btn btn-primary" @onclick="BeginGuided">Start Guided Scan</button>
                 </div>
-            </div>
-            <ul class="nav nav-tabs mb-3" id="options-tabs" role="tablist">
-                <li class="nav-item">
-                    <a class="nav-link active" id="collectors-tab" data-toggle="tab" href="#collectors" role="tab" aria-controls="collectors" aria-selected="true">Collectors</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" id="monitor-tab" data-toggle="tab" href="#monitor" role="tab" aria-controls="monitor" aria-selected="false">Monitor</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" id="analyze-tab" data-toggle="tab" href="#analyze" role="tab" aria-controls="analyze" aria-selected="false">Analyze</a>
-                </li>
-            </ul>
-            <div class="tab-content" id="options-tabs-content">
-                <div class="tab-pane fade show active" id="collectors" role="tabpanel" aria-labelledby="collectors-tab">
-                    <CollectorOptionsRazor />
+                <ul class="nav nav-tabs mb-3" id="options-tabs" role="tablist">
+                    <li class="nav-item">
+                        <a class="nav-link active" id="collectors-tab" data-toggle="tab" href="#collectors" role="tab" aria-controls="collectors" aria-selected="true">Collectors</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" id="monitor-tab" data-toggle="tab" href="#monitor" role="tab" aria-controls="monitor" aria-selected="false">Monitor</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" id="analyze-tab" data-toggle="tab" href="#analyze" role="tab" aria-controls="analyze" aria-selected="false">Analyze</a>
+                    </li>
+                </ul>
+                <div class="tab-content" id="options-tabs-content">
+                    <div class="tab-pane fade show active" id="collectors" role="tabpanel" aria-labelledby="collectors-tab">
+                        <CollectorOptionsRazor />
+                    </div>
+                    <div class="tab-pane fade" id="monitor" role="tabpanel" aria-labelledby="monitor-tab">
+                        <MonitorOptionsRazor />
+                    </div>
+                    <div class="tab-pane fade" id="analyze" role="tabpanel" aria-labelledby="analyze-tab">
+                        <AnalyzeOptionsRazor />
+                    </div>
                 </div>
-                <div class="tab-pane fade" id="monitor" role="tabpanel" aria-labelledby="monitor-tab">
-                    <MonitorOptionsRazor />
-                </div>
-                <div class="tab-pane fade" id="analyze" role="tabpanel" aria-labelledby="analyze-tab">
-                    <AnalyzeOptionsRazor />
-                </div>
-            </div>
 
-            break;
-        case PageState.Scanning:
-            <Scanning />
-            break;
-        case PageState.Monitoring:
-            <Monitoring Continue="@ContinueGuided" />
-            break;
-        case PageState.MonitorFlushing:
-            <MonitorFlushing />
-            break;
-        case PageState.Analyzing:
-            <Analyzing />
-            break;
-        case PageState.Results:
-            <Results FirstRunId="@appData.ExportCollectCommandOptions.FirstRunId" SecondRunId="@appData.ExportCollectCommandOptions.SecondRunId" AnalysesHash="@appData.CompareCommandOptions.AnalysesFile?.GetHash()" MonitorRunId="@appData.MonitorOptions.RunId" />
-            break;
-        case PageState.Error:
-            <p>An Error Occured while collecting.</p>
-            break;
+                break;
+            case GuidedPageState.Scanning:
+                <Scanning />
+                break;
+            case GuidedPageState.Monitoring:
+                <Monitoring Continue="@ContinueGuided" />
+                break;
+            case GuidedPageState.MonitorFlushing:
+                <MonitorFlushing />
+                break;
+            case GuidedPageState.Analyzing:
+                <Analyzing />
+                break;
+            case GuidedPageState.Results:
+                <button class="btn btn-primary" @onclick="Reset">Start Again</button>
+                <Results FirstRunId="@appData.ExportCollectCommandOptions.FirstRunId" SecondRunId="@appData.ExportCollectCommandOptions.SecondRunId" AnalysesHash="@appData.CompareCommandOptions.AnalysesFile?.GetHash()" MonitorRunId="@appData.MonitorOptions.RunId" />
+                break;
+            case GuidedPageState.Error:
+                <p>An Error Occured while collecting.</p>
+                <button @onclick="Reset">Restart</button>
+                break;
+        }
     }
 </div>
 
 @code{
-    enum PageState
-    {
-        Options,
-        Scanning,
-        Monitoring,
-        MonitorFlushing,
-        Analyzing,
-        Results,
-        Error
-    }
+
 
     bool UseTimestamp = true;
     string RunIdInput = "";
 
-    PageState pageState = PageState.Options;
+    string GetPlaceholder()
+    {
+        return UseTimestamp ? "Timestamp Will Be Used" : "Enter Run ID";
+    }
+
+    void Reset()
+    {
+        appData.guidedPageState = GuidedPageState.Options;
+    }
+
+    bool TrySetExclusive()
+    {
+        if (appData.exclusiveMode == ExclusiveMode.None)
+        {
+            appData.exclusiveMode = ExclusiveMode.Guided;
+            return true;
+        }
+        return false;
+    }
+
+    void ResetExclusive()
+    {
+        if (appData.exclusiveMode == ExclusiveMode.Guided)
+        {
+            appData.exclusiveMode = ExclusiveMode.None;
+        }
+    }
 
     async void BeginGuided()
     {
-        appData.RunId = UseTimestamp ? DateTime.Now.ToString() : RunIdInput;
-        timer = new System.Threading.Timer((_) => InvokeAsync(() => StateHasChanged()), null, 0, 100);
-        appData.CollectOptions.RunId = appData.FirstRunId;
-        if (await BeginScan() == ASA_ERROR.NONE)
+        if (TrySetExclusive())
         {
-            appData.MonitorOptions.RunId = appData.MonitorRunId;
-            await BeginMonitor();
-            AttackSurfaceAnalyzerClient.ClearCollectors();
+            appData.RunId = UseTimestamp ? DateTime.Now.ToString() : RunIdInput;
+            timer = new System.Threading.Timer((_) => InvokeAsync(() => StateHasChanged()), null, 0, 100);
+            appData.CollectOptions.RunId = appData.FirstRunId;
+            if (await BeginScan() == ASA_ERROR.NONE)
+            {
+                appData.MonitorOptions.RunId = appData.MonitorRunId;
+                await BeginMonitor();
+                AttackSurfaceAnalyzerClient.ClearCollectors();
+            }
+            else
+            {
+                appData.guidedPageState = GuidedPageState.Error;
+                appData.exclusiveMode = ExclusiveMode.None;
+            }        
         }
         else
         {
-            pageState = PageState.Error;
+            appData.monitorPageState = MonitorPageState.Error;
         }
     }
 
     async void ContinueGuided()
     {
-        pageState = PageState.MonitorFlushing;
+        appData.guidedPageState = GuidedPageState.MonitorFlushing;
         this.StateHasChanged();
-        AttackSurfaceAnalyzerClient.StopMonitors();
+        await Task.Factory.StartNew(() => AttackSurfaceAnalyzerClient.StopMonitors());
         while (AttackSurfaceAnalyzerClient.DatabaseManager?.HasElements ?? false)
         {
             Thread.Sleep(1);
@@ -119,28 +158,29 @@
         appData.ExportCollectCommandOptions.FirstRunId = appData.FirstRunId;
         appData.ExportCollectCommandOptions.SecondRunId = appData.SecondRunId;
         await BeginAnalyze();
-        pageState = PageState.Results;
+        appData.guidedPageState = GuidedPageState.Results;
+        ResetExclusive();
     }
 
     System.Threading.Timer timer = new Timer((_) => { }, null, int.MaxValue, Timeout.Infinite);
 
     async Task<ASA_ERROR> BeginScan()
     {
-        pageState = PageState.Scanning;
+        appData.guidedPageState = GuidedPageState.Scanning;
         this.StateHasChanged();
         return await Task.Factory.StartNew(() => AttackSurfaceAnalyzerClient.RunCollectCommand(appData.CollectOptions));
     }
 
     async Task<ASA_ERROR> BeginMonitor()
     {
-        pageState = PageState.Monitoring;
+        appData.guidedPageState = GuidedPageState.Monitoring;
         this.StateHasChanged();
         return await Task.Factory.StartNew(() => AttackSurfaceAnalyzerClient.RunGuiMonitorCommand(appData.MonitorOptions));
     }
 
     async Task<ASA_ERROR> BeginAnalyze()
     {
-        pageState = PageState.Analyzing;
+        appData.guidedPageState = GuidedPageState.Analyzing;
 
         await Task.Factory.StartNew(() =>
         {

--- a/Cli/Pages/Monitor.razor
+++ b/Cli/Pages/Monitor.razor
@@ -4,11 +4,11 @@
 <h4>Monitor</h4>
 
 <div class="container-fluid bg-custom my-1 pb-1">
-    @if (appData.exclusiveMode == ExclusiveMode.Scan)
+    @if (appData.exclusiveMode == Mode.Scan)
     {
         <p>You cannot start monitoring while scanning. Complete your existing scan first.</p>
     }
-    else if (appData.exclusiveMode == ExclusiveMode.Guided)
+    else if (appData.exclusiveMode == Mode.Guided)
     {
         <p>You cannot start montoring while running a guided mode scan. Complete your guided mode scan first.</p>
     }
@@ -58,9 +58,9 @@
 
     bool TrySetExclusive()
     {
-        if (appData.exclusiveMode == ExclusiveMode.None)
+        if (appData.exclusiveMode == Mode.None)
         {
-            appData.exclusiveMode = ExclusiveMode.Monitor;
+            appData.exclusiveMode = Mode.Monitor;
             return true;
         }
         return false;
@@ -68,9 +68,9 @@
 
     void ResetExclusive()
     {
-        if (appData.exclusiveMode == ExclusiveMode.Monitor)
+        if (appData.exclusiveMode == Mode.Monitor)
         {
-            appData.exclusiveMode = ExclusiveMode.None;
+            appData.exclusiveMode = Mode.None;
         }
     }
 

--- a/Cli/Pages/Monitor.razor
+++ b/Cli/Pages/Monitor.razor
@@ -54,7 +54,7 @@
     bool UseTimestamp = true;
     string RunIdInput = "";
 
-    System.Threading.Timer timer  = new Timer((_) => { });
+    System.Threading.Timer? timer;
 
     bool TrySetExclusive()
     {

--- a/Cli/Pages/Monitor.razor
+++ b/Cli/Pages/Monitor.razor
@@ -54,7 +54,7 @@
     bool UseTimestamp = true;
     string RunIdInput = "";
 
-    System.Threading.Timer timer  = new Timer((_) => { }, null, int.MaxValue, Timeout.Infinite);
+    System.Threading.Timer timer  = new Timer((_) => { });
 
     bool TrySetExclusive()
     {

--- a/Cli/Pages/Monitor.razor
+++ b/Cli/Pages/Monitor.razor
@@ -1,85 +1,116 @@
 ﻿@page "/monitor"
+@using static Microsoft.CST.AttackSurfaceAnalyzer.Cli.AppData
 
 <h4>Monitor</h4>
 
 <div class="container-fluid bg-custom my-1 pb-1">
-    @switch (pageState)
+    @if (appData.exclusiveMode == ExclusiveMode.Scan)
     {
-        case PageState.Options:
-            <div class="run-box bg-custom">
-                <div class="form-inline">
-                    <label class="mr-2" for="RunId">Run ID:</label>
-                    <input type="text" class="form-control mr-2" id="RunId" placeholder="Enter Run ID" @bind="RunIdInput" />
-                    <div class="form-check mr-2">
-                        <input type="checkbox" class="form-check-input" id="UseTimestampCheckbox" @bind="UseTimestamp" />
-                        <label class="form-check-label" for="UseTimestampCheckbox">Use Timestamp</label>
+        <p>You cannot start monitoring while scanning. Complete your existing scan first.</p>
+    }
+    else if (appData.exclusiveMode == ExclusiveMode.Guided)
+    {
+        <p>You cannot start montoring while running a guided mode scan. Complete your guided mode scan first.</p>
+    }
+    else
+    {
+        @switch (appData.monitorPageState)
+        {
+            case MonitorPageState.Options:
+                <div class="run-box bg-custom">
+                    <div class="form-inline">
+                        <label class="mr-2" for="RunId">Run ID:</label>
+                        <input type="text" class="form-control mr-2" id="RunId" placeholder="Enter Run ID" @bind="RunIdInput" />
+                        <div class="form-check mr-2">
+                            <input type="checkbox" class="form-check-input" id="UseTimestampCheckbox" @bind="UseTimestamp" />
+                            <label class="form-check-label" for="UseTimestampCheckbox">Use Timestamp</label>
+                        </div>
+                        <button class="btn btn-primary" @onclick="BeginMonitor">Start Monitor</button>
                     </div>
-                    <button class="btn btn-primary" @onclick="BeginMonitor">Start Monitor</button>
                 </div>
-            </div>
-            <MonitorOptionsRazor />
-            break;
-        case PageState.Monitoring:
-            <Monitoring Continue="@FinishMonitor" />
-            break;
-        case PageState.MonitorFlushing:
-            <MonitorFlushing />
-            break;
-        case PageState.Finished:
-            <p>Monitoring complete.</p>
-            <button class="btn btn-primary" @onclick="GoToOptions">Monitor Again</button>
-            break;
-        case PageState.Error:
-            <p>An Error Occured while monitoring.</p>
-            break;
+                <MonitorOptionsRazor />
+                break;
+            case MonitorPageState.Monitoring:
+                <Monitoring Continue="@FinishMonitor" />
+                break;
+            case MonitorPageState.MonitorFlushing:
+                <MonitorFlushing />
+                break;
+            case MonitorPageState.Finished:
+                <p>Monitoring complete.</p>
+                <button class="btn btn-primary" @onclick="GoToOptions">Monitor Again</button>
+                break;
+            case MonitorPageState.Error:
+                <p>An Error Occured while monitoring.</p>
+                <button class="btn btn-primary" @onclick="GoToOptions">Restart</button>
+                break;
+        }
     }
 </div>
 
 @code {
-    enum PageState
-    {
-        Options,
-        Monitoring,
-        MonitorFlushing,
-        Finished,
-        Error
-    }
+
 
     bool UseTimestamp = true;
     string RunIdInput = "";
 
-    PageState pageState = PageState.Options;
-
     System.Threading.Timer timer  = new Timer((_) => { }, null, int.MaxValue, Timeout.Infinite);
+
+    bool TrySetExclusive()
+    {
+        if (appData.exclusiveMode == ExclusiveMode.None)
+        {
+            appData.exclusiveMode = ExclusiveMode.Monitor;
+            return true;
+        }
+        return false;
+    }
+
+    void ResetExclusive()
+    {
+        if (appData.exclusiveMode == ExclusiveMode.Monitor)
+        {
+            appData.exclusiveMode = ExclusiveMode.None;
+        }
+    }
 
     async void BeginMonitor()
     {
-        appData.RunId = UseTimestamp ? DateTime.Now.ToString() : RunIdInput;
-        timer = new System.Threading.Timer((_) => InvokeAsync(() => StateHasChanged()), null, 0, 100);
-        appData.MonitorOptions.RunId = appData.MonitorRunId;
-
-        pageState = PageState.Monitoring;
-        this.StateHasChanged();
-
-        if (await Task.Factory.StartNew(() => AttackSurfaceAnalyzerClient.RunGuiMonitorCommand(appData.MonitorOptions)) != Microsoft.CST.AttackSurfaceAnalyzer.Types.ASA_ERROR.NONE)
+        if (TrySetExclusive())
         {
-            pageState = PageState.Error;
-        }
+            appData.RunId = UseTimestamp ? DateTime.Now.ToString() : RunIdInput;
+            timer = new System.Threading.Timer((_) => InvokeAsync(() => StateHasChanged()), null, 0, 100);
+            appData.MonitorOptions.RunId = appData.MonitorRunId;
 
-        this.StateHasChanged();
+            appData.monitorPageState = MonitorPageState.Monitoring;
+            this.StateHasChanged();
+
+            if (await Task.Factory.StartNew(() => AttackSurfaceAnalyzerClient.RunGuiMonitorCommand(appData.MonitorOptions)) != Microsoft.CST.AttackSurfaceAnalyzer.Types.ASA_ERROR.NONE)
+            {
+                appData.monitorPageState = MonitorPageState.Error;
+            }
+
+            this.StateHasChanged();
+        }
+        else
+        {
+            appData.monitorPageState = MonitorPageState.Error;
+        }
+        
     }
 
     void FinishMonitor()
     {
-        pageState = PageState.MonitorFlushing;
+        appData.monitorPageState = MonitorPageState.MonitorFlushing;
         this.StateHasChanged();
         AttackSurfaceAnalyzerClient.StopMonitors();
-        pageState = PageState.Finished;
+        appData.monitorPageState = MonitorPageState.Finished;
         this.StateHasChanged();
+        ResetExclusive();
     }
 
     void GoToOptions()
     {
-        pageState = PageState.Options;
+        appData.monitorPageState = MonitorPageState.Options;
     }
 }

--- a/Cli/Pages/Report.razor
+++ b/Cli/Pages/Report.razor
@@ -21,7 +21,13 @@
             </select>
         </div>
     </div>
-    <Results FirstRunId="@Runs[RunIdInput].firstRunId" SecondRunId="@Runs[RunIdInput].secondRunId" AnalysesHash="@Runs[RunIdInput].analysesHash" MonitorRunId="@Runs[RunIdInput].secondRunId" />
+    @if (string.IsNullOrEmpty(Runs[RunIdInput].firstRunId)){
+        <Results AnalysesHash="@Runs[RunIdInput].analysesHash" MonitorRunId="@Runs[RunIdInput].secondRunId" />
+    }
+    else
+    {
+        <Results FirstRunId="@Runs[RunIdInput].firstRunId" SecondRunId="@Runs[RunIdInput].secondRunId" AnalysesHash="@Runs[RunIdInput].analysesHash" />
+    }
 }
 else
 {

--- a/Cli/Pages/Sandbox.razor
+++ b/Cli/Pages/Sandbox.razor
@@ -307,7 +307,7 @@
         {
             _typeToInvoke = value;
             var constructors = Types.Where(x => x.Key.FullName == value).FirstOrDefault().Value;
-            if (constructors.Any())
+            if (constructors?.Any() ?? false)
             {
                 var constructorToUse = constructors[constructorToInvoke];
                 ScaffoldedObject = new Scaffold(constructorToUse);
@@ -372,6 +372,7 @@
             }
         }
         Types = results;
+        typeToInvoke = Types.Keys.FirstOrDefault()?.Name ?? string.Empty;
         RefreshState();
     }
 

--- a/Cli/Pages/Sandbox.razor
+++ b/Cli/Pages/Sandbox.razor
@@ -68,7 +68,7 @@
                 }
                 @if (ScaffoldedObject != null)
                 {
-                    <ScaffoldInput Object="this" SubPath="ScaffoldedObject" Assemblies="Assemblies" />
+                    <ScaffoldInput Object="this" SubPath="ScaffoldedObject" />
                 }
             </div>
         </div>

--- a/Cli/Pages/Sandbox.razor
+++ b/Cli/Pages/Sandbox.razor
@@ -63,7 +63,7 @@
                     if (types.Any())
                     {
                         var type = types.FirstOrDefault();
-                        <button class="btn btn-primary mb-1" @onclick="AddObject">Add @type.Key.FullName</button>
+                        <button class="btn btn-primary mb-1" @onclick="AddObject">Add @type.Key.Name</button>
                     }
                 }
                 @if (ScaffoldedObject != null)
@@ -372,7 +372,7 @@
             }
         }
         Types = results;
-        typeToInvoke = Types.Keys.FirstOrDefault()?.Name ?? string.Empty;
+        typeToInvoke = Types.Keys.FirstOrDefault()?.FullName ?? string.Empty;
         RefreshState();
     }
 

--- a/Cli/Pages/Scan.razor
+++ b/Cli/Pages/Scan.razor
@@ -5,168 +5,46 @@
 <div class="container-fluid bg-custom my-1 pb-1">
     @if (appData.exclusiveMode == Mode.Monitor)
     {
-        
-
-#line default
-#line hidden
-#nullable disable
-#nullable restore
-#line 8 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
-                                                                                        
+        <p>You cannot start a scan while monitoring. Complete your monitoring first.</p>
     }
     else if (appData.exclusiveMode == Mode.Guided)
     {
-        
-
-#line default
-#line hidden
-#nullable disable
-#nullable restore
-#line 12 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
-                                                                                                              
+        <p>You cannot start a scan while running a guided mode scan. Complete your guided mode scan first.</p>
     }
     else
     {
-        
-
-#line default
-#line hidden
-#nullable disable
-#nullable restore
-#line 16 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
-         switch (appData.scanPageState)
+        @switch (appData.scanPageState)
         {
             case ScanPageState.Options:
-                
-
-#line default
-#line hidden
-#nullable disable
-            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
-#nullable restore
-#line 22 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
-                                                                                                                  RunIdInput
-
-#line default
-#line hidden
-#nullable disable
-            );
-            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => RunIdInput = __value, RunIdInput);
-            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
-#nullable restore
-#line 24 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
-                                                                                                             UseTimestamp
-
-#line default
-#line hidden
-#nullable disable
-            );
-            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => UseTimestamp = __value, UseTimestamp);
-            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, 
-#nullable restore
-#line 27 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
-                                                                  BeginScan
-
-#line default
-#line hidden
-#nullable disable
-            );
-                      
-                
-            __builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
-            }
-            ));
-#nullable restore
-#line 30 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
-__o = typeof(CollectorOptionsRazor);
-
-#line default
-#line hidden
-#nullable disable
-#nullable restore
-#line 30 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
-                                         
+                <div class="run-box bg-custom">
+                    <div class="form-inline">
+                        <label class="mr-2" for="RunId">Run ID:</label>
+                        <input type="text" class="form-control mr-2" id="RunId" placeholder="Enter Run ID" @bind="RunIdInput" />
+                        <div class="form-check mr-2">
+                            <input type="checkbox" class="form-check-input" id="UseTimestampCheckbox" @bind="UseTimestamp" />
+                            <label class="form-check-label" for="UseTimestampCheckbox">Use Timestamp</label>
+                        </div>
+                        <button class="btn btn-primary" @onclick="BeginScan">Start Scan</button>
+                    </div>
+                </div>
+                <CollectorOptionsRazor />
                 break;
             case ScanPageState.Scanning:
-                
-
-#line default
-#line hidden
-#nullable disable
-            __builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
-            }
-            ));
-#nullable restore
-#line 33 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
-__o = typeof(Scanning);
-
-#line default
-#line hidden
-#nullable disable
-#nullable restore
-#line 33 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
-                            
+                <Scanning />
                 break;
             case ScanPageState.Finished:
-                
-
-#line default
-#line hidden
-#nullable disable
-                                         
-                
-            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, 
-#nullable restore
-#line 37 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
-                                                          GoToOptions
-
-#line default
-#line hidden
-#nullable disable
-            );
-#nullable restore
-#line 37 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
-                                                                                          
+                <p>Scanning complete.</p>
+                <button class="btn btn-primary" @onclick="GoToOptions">Scan Again</button>
                 break;
             case ScanPageState.Error:
-                
-
-#line default
-#line hidden
-#nullable disable
-                                                         
-                
-            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, 
-#nullable restore
-#line 41 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
-                                                          GoToOptions
-
-#line default
-#line hidden
-#nullable disable
-            );
-#nullable restore
-#line 41 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
-                                                                                       
+                <p>An Error Occured while collecting.</p>
+                <button class="btn btn-primary" @onclick="GoToOptions">Restart</button>
                 break;
         }
-
-#line default
-#line hidden
-#nullable disable
-#nullable restore
-#line 43 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
-         
     }
+</div>
 
-#line default
-#line hidden
-#nullable disable
-        }
-        #pragma warning restore 1998
-#nullable restore
-#line 47 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
-       
+@code {
     bool UseTimestamp = true;
     string RunIdInput = "";
 

--- a/Cli/Pages/Scan.razor
+++ b/Cli/Pages/Scan.razor
@@ -48,7 +48,7 @@
     bool UseTimestamp = true;
     string RunIdInput = "";
 
-    System.Threading.Timer timer = new Timer((_) => { });
+    System.Threading.Timer? timer;
 
     bool TrySetExclusive()
     {

--- a/Cli/Pages/Scan.razor
+++ b/Cli/Pages/Scan.razor
@@ -48,7 +48,7 @@
     bool UseTimestamp = true;
     string RunIdInput = "";
 
-    System.Threading.Timer timer = new Timer((_) => { }, null, int.MaxValue, Timeout.Infinite);
+    System.Threading.Timer timer = new Timer((_) => { });
 
     bool TrySetExclusive()
     {

--- a/Cli/Pages/Scan.razor
+++ b/Cli/Pages/Scan.razor
@@ -3,48 +3,170 @@
 
 <h4>Scan</h4>
 <div class="container-fluid bg-custom my-1 pb-1">
-    @if (appData.exclusiveMode == ExclusiveMode.Monitor)
+    @if (appData.exclusiveMode == Mode.Monitor)
     {
-        <p>You cannot start a scan while monitoring. Complete your monitoring first.</p>
+        
+
+#line default
+#line hidden
+#nullable disable
+#nullable restore
+#line 8 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
+                                                                                        
     }
-    else if (appData.exclusiveMode == ExclusiveMode.Guided)
+    else if (appData.exclusiveMode == Mode.Guided)
     {
-        <p>You cannot start a scan while running a guided mode scan. Complete your guided mode scan first.</p>
+        
+
+#line default
+#line hidden
+#nullable disable
+#nullable restore
+#line 12 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
+                                                                                                              
     }
     else
     {
-        @switch (appData.scanPageState)
+        
+
+#line default
+#line hidden
+#nullable disable
+#nullable restore
+#line 16 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
+         switch (appData.scanPageState)
         {
             case ScanPageState.Options:
-                <div class="run-box bg-custom">
-                    <div class="form-inline">
-                        <label class="mr-2" for="RunId">Run ID:</label>
-                        <input type="text" class="form-control mr-2" id="RunId" placeholder="Enter Run ID" @bind="RunIdInput" />
-                        <div class="form-check mr-2">
-                            <input type="checkbox" class="form-check-input" id="UseTimestampCheckbox" @bind="UseTimestamp" />
-                            <label class="form-check-label" for="UseTimestampCheckbox">Use Timestamp</label>
-                        </div>
-                        <button class="btn btn-primary" @onclick="BeginScan">Start Scan</button>
-                    </div>
-                </div>
-                <CollectorOptionsRazor />
+                
+
+#line default
+#line hidden
+#nullable disable
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
+#nullable restore
+#line 22 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
+                                                                                                                  RunIdInput
+
+#line default
+#line hidden
+#nullable disable
+            );
+            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => RunIdInput = __value, RunIdInput);
+            __o = Microsoft.AspNetCore.Components.BindConverter.FormatValue(
+#nullable restore
+#line 24 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
+                                                                                                             UseTimestamp
+
+#line default
+#line hidden
+#nullable disable
+            );
+            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, __value => UseTimestamp = __value, UseTimestamp);
+            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, 
+#nullable restore
+#line 27 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
+                                                                  BeginScan
+
+#line default
+#line hidden
+#nullable disable
+            );
+                      
+                
+            __builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
+            }
+            ));
+#nullable restore
+#line 30 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
+__o = typeof(CollectorOptionsRazor);
+
+#line default
+#line hidden
+#nullable disable
+#nullable restore
+#line 30 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
+                                         
                 break;
             case ScanPageState.Scanning:
-                <Scanning />
+                
+
+#line default
+#line hidden
+#nullable disable
+            __builder.AddAttribute(-1, "ChildContent", (Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
+            }
+            ));
+#nullable restore
+#line 33 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
+__o = typeof(Scanning);
+
+#line default
+#line hidden
+#nullable disable
+#nullable restore
+#line 33 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
+                            
                 break;
             case ScanPageState.Finished:
-                <p>Scanning complete.</p>
-                <button class="btn btn-primary" @onclick="GoToOptions">Scan Again</button>
+                
+
+#line default
+#line hidden
+#nullable disable
+                                         
+                
+            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, 
+#nullable restore
+#line 37 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
+                                                          GoToOptions
+
+#line default
+#line hidden
+#nullable disable
+            );
+#nullable restore
+#line 37 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
+                                                                                          
                 break;
             case ScanPageState.Error:
-                <p>An Error Occured while collecting.</p>
-                <button class="btn btn-primary" @onclick="GoToOptions">Restart</button>
+                
+
+#line default
+#line hidden
+#nullable disable
+                                                         
+                
+            __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.MouseEventArgs>(this, 
+#nullable restore
+#line 41 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
+                                                          GoToOptions
+
+#line default
+#line hidden
+#nullable disable
+            );
+#nullable restore
+#line 41 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
+                                                                                       
                 break;
         }
-    }
-</div>
 
-@code {
+#line default
+#line hidden
+#nullable disable
+#nullable restore
+#line 43 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
+         
+    }
+
+#line default
+#line hidden
+#nullable disable
+        }
+        #pragma warning restore 1998
+#nullable restore
+#line 47 "c:/Users/gstocco/Documents/GitHub/AttackSurfaceAnalyzer/Cli/Pages/Scan.razor"
+       
     bool UseTimestamp = true;
     string RunIdInput = "";
 
@@ -52,9 +174,9 @@
 
     bool TrySetExclusive()
     {
-        if (appData.exclusiveMode == ExclusiveMode.None)
+        if (appData.exclusiveMode == Mode.None)
         {
-            appData.exclusiveMode = ExclusiveMode.Scan;
+            appData.exclusiveMode = Mode.Scan;
             return true;
         }
         return false;
@@ -62,9 +184,9 @@
 
     void ResetExclusive()
     {
-        if (appData.exclusiveMode == ExclusiveMode.Scan)
+        if (appData.exclusiveMode == Mode.Scan)
         {
-            appData.exclusiveMode = ExclusiveMode.None;
+            appData.exclusiveMode = Mode.None;
         }
     }
 

--- a/Cli/Pages/Scan.razor
+++ b/Cli/Pages/Scan.razor
@@ -1,71 +1,102 @@
 ﻿@page "/scan"
+@using static Microsoft.CST.AttackSurfaceAnalyzer.Cli.AppData
 
 <h4>Scan</h4>
 <div class="container-fluid bg-custom my-1 pb-1">
-    @switch (pageState)
+    @if (appData.exclusiveMode == ExclusiveMode.Monitor)
     {
-        case PageState.Options:
-            <div class="run-box bg-custom">
-                <div class="form-inline">
-                    <label class="mr-2" for="RunId">Run ID:</label>
-                    <input type="text" class="form-control mr-2" id="RunId" placeholder="Enter Run ID" @bind="RunIdInput" />
-                    <div class="form-check mr-2">
-                        <input type="checkbox" class="form-check-input" id="UseTimestampCheckbox" @bind="UseTimestamp" />
-                        <label class="form-check-label" for="UseTimestampCheckbox">Use Timestamp</label>
+        <p>You cannot start a scan while monitoring. Complete your monitoring first.</p>
+    }
+    else if (appData.exclusiveMode == ExclusiveMode.Guided)
+    {
+        <p>You cannot start a scan while running a guided mode scan. Complete your guided mode scan first.</p>
+    }
+    else
+    {
+        @switch (appData.scanPageState)
+        {
+            case ScanPageState.Options:
+                <div class="run-box bg-custom">
+                    <div class="form-inline">
+                        <label class="mr-2" for="RunId">Run ID:</label>
+                        <input type="text" class="form-control mr-2" id="RunId" placeholder="Enter Run ID" @bind="RunIdInput" />
+                        <div class="form-check mr-2">
+                            <input type="checkbox" class="form-check-input" id="UseTimestampCheckbox" @bind="UseTimestamp" />
+                            <label class="form-check-label" for="UseTimestampCheckbox">Use Timestamp</label>
+                        </div>
+                        <button class="btn btn-primary" @onclick="BeginScan">Start Scan</button>
                     </div>
-                    <button class="btn btn-primary" @onclick="BeginScan">Start Scan</button>
                 </div>
-            </div>
-            <CollectorOptionsRazor />
-            break;
-        case PageState.Scanning:
-            <Scanning />
-            break;
-        case PageState.Finished:
-            <p>Scanning complete.</p>
-            <button class="btn btn-primary" @onclick="GoToOptions">Scan Again</button>
-            break;
-        case PageState.Error:
-            <p>An Error Occured while collecting.</p>
-            break;
+                <CollectorOptionsRazor />
+                break;
+            case ScanPageState.Scanning:
+                <Scanning />
+                break;
+            case ScanPageState.Finished:
+                <p>Scanning complete.</p>
+                <button class="btn btn-primary" @onclick="GoToOptions">Scan Again</button>
+                break;
+            case ScanPageState.Error:
+                <p>An Error Occured while collecting.</p>
+                <button class="btn btn-primary" @onclick="GoToOptions">Restart</button>
+                break;
+        }
     }
 </div>
 
 @code {
-    enum PageState
-    {
-        Options,
-        Scanning,
-        Finished,
-        Error
-    }
     bool UseTimestamp = true;
     string RunIdInput = "";
 
-    PageState pageState = PageState.Options;
-
     System.Threading.Timer timer = new Timer((_) => { }, null, int.MaxValue, Timeout.Infinite);
+
+    bool TrySetExclusive()
+    {
+        if (appData.exclusiveMode == ExclusiveMode.None)
+        {
+            appData.exclusiveMode = ExclusiveMode.Scan;
+            return true;
+        }
+        return false;
+    }
+
+    void ResetExclusive()
+    {
+        if (appData.exclusiveMode == ExclusiveMode.Scan)
+        {
+            appData.exclusiveMode = ExclusiveMode.None;
+        }
+    }
 
     async void BeginScan()
     {
-        appData.RunId = UseTimestamp ? DateTime.Now.ToString() : RunIdInput;
-        timer = new System.Threading.Timer((_) => InvokeAsync(() => StateHasChanged()), null, 0, 100);
-        appData.CollectOptions.RunId = appData.FirstRunId;
-        pageState = PageState.Scanning;
-        this.StateHasChanged();
-        if (await Task.Factory.StartNew(() => AttackSurfaceAnalyzerClient.RunCollectCommand(appData.CollectOptions)) == Microsoft.CST.AttackSurfaceAnalyzer.Types.ASA_ERROR.NONE)
+        if (TrySetExclusive())
         {
-            pageState = PageState.Finished;
+            appData.RunId = UseTimestamp ? DateTime.Now.ToString() : RunIdInput;
+            timer = new System.Threading.Timer((_) => InvokeAsync(() => StateHasChanged()), null, 0, 100);
+            appData.CollectOptions.RunId = appData.FirstRunId;
+            appData.scanPageState = ScanPageState.Scanning;
+            this.StateHasChanged();
+            if (await Task.Factory.StartNew(() => AttackSurfaceAnalyzerClient.RunCollectCommand(appData.CollectOptions)) == Microsoft.CST.AttackSurfaceAnalyzer.Types.ASA_ERROR.NONE)
+            {
+                appData.scanPageState = ScanPageState.Finished;
+            }
+            else
+            {
+                appData.scanPageState = ScanPageState.Error;
+            }
+            AttackSurfaceAnalyzerClient.ClearCollectors();
+            ResetExclusive();
         }
         else
         {
-            pageState = PageState.Error;
+            appData.scanPageState = ScanPageState.Error;
         }
-        AttackSurfaceAnalyzerClient.ClearCollectors();
+        
     }
 
     void GoToOptions()
     {
-        pageState = PageState.Options;
+        appData.scanPageState = ScanPageState.Options;
     }
 }

--- a/Lib/Collectors/BaseCompare.cs
+++ b/Lib/Collectors/BaseCompare.cs
@@ -36,41 +36,6 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
 
         public ConcurrentDictionary<(RESULT_TYPE, CHANGE_TYPE), List<CompareResult>> Results { get; }
 
-        /// <summary>
-        ///     Creates a list of Diff objects based on an object property and findings.
-        /// </summary>
-        /// <param name="prop"> The property of the referenced object. </param>
-        /// <param name="added"> The added findings. </param>
-        /// <param name="removed"> The removed findings. </param>
-        /// <returns> </returns>
-        public static List<Diff> GetDiffs(PropertyInfo prop, object? added, object? removed)
-        {
-            List<Diff> diffsOut = new List<Diff>();
-            if (added != null && prop != null)
-            {
-                diffsOut.Add(new Diff(FieldIn: prop.Name, AfterIn: added));
-            }
-            if (removed != null && prop != null)
-            {
-                diffsOut.Add(new Diff(FieldIn: prop.Name, BeforeIn: removed));
-            }
-            return diffsOut;
-        }
-
-        public static List<Diff> GetDiffs(FieldInfo field, object? added, object? removed)
-        {
-            List<Diff> diffsOut = new List<Diff>();
-            if (added != null && field != null)
-            {
-                diffsOut.Add(new Diff(FieldIn: field.Name, AfterIn: added));
-            }
-            if (removed != null && field != null)
-            {
-                diffsOut.Add(new Diff(FieldIn: field.Name, BeforeIn: removed));
-            }
-            return diffsOut;
-        }
-
         public void Compare(IEnumerable<CollectObject> FirstRunObjects, IEnumerable<CollectObject> SecondRunObjects, string? firstRunId, string secondRunId)
         {
             if (firstRunId == null)
@@ -229,12 +194,12 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
                     else if (firstProp == null && secondProp != null)
                     {
                         added = prop.GetValue(second);
-                        diffs.AddRange(GetDiffs(prop, added, null));
+                        diffs.Add(new Diff(prop.Name, added, null));
                     }
                     else if (secondProp == null && firstProp != null)
                     {
                         removed = prop.GetValue(first);
-                        diffs.AddRange(GetDiffs(prop, null, removed));
+                        diffs.Add(new Diff(prop.Name, null, removed));
                     }
                     else
                     {
@@ -333,7 +298,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
                             diffs.Add(new Diff(prop.Name, firstVal, secondVal));
                         }
 
-                        diffs.AddRange(GetDiffs(prop, added, removed));
+                        diffs.Add(new Diff(prop.Name, added, removed));
                     }
                 }
                 catch (InvalidCastException e)
@@ -386,12 +351,12 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
                     else if (firstField == null && secondField != null)
                     {
                         added = field.GetValue(second);
-                        diffs.AddRange(GetDiffs(field, added, null));
+                        diffs.Add(new Diff(field.Name, added, null));
                     }
                     else if (secondField == null && firstField != null)
                     {
                         removed = field.GetValue(first);
-                        diffs.AddRange(GetDiffs(field, null, removed));
+                        diffs.Add(new Diff(field.Name, null, removed));
                     }
                     else
                     {
@@ -490,7 +455,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
                             diffs.Add(new Diff(field.Name, firstVal, secondVal));
                         }
 
-                        diffs.AddRange(GetDiffs(field, added, removed));
+                        diffs.AddRange(new Diff(field.Name, added, removed));
                     }
                 }
                 catch (InvalidCastException e)

--- a/Lib/Collectors/BaseCompare.cs
+++ b/Lib/Collectors/BaseCompare.cs
@@ -501,7 +501,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
         /// <summary>
         ///     Set status to running.
         /// </summary>
-        public void Start()
+        private void Start()
         {
             _running = RUN_STATUS.RUNNING;
         }
@@ -509,7 +509,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
         /// <summary>
         ///     Sets status to completed.
         /// </summary>
-        public void Stop()
+        private void Stop()
         {
             _running = RUN_STATUS.COMPLETED;
         }

--- a/Lib/Collectors/BaseCompare.cs
+++ b/Lib/Collectors/BaseCompare.cs
@@ -455,7 +455,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
                             diffs.Add(new Diff(field.Name, firstVal, secondVal));
                         }
 
-                        diffs.AddRange(new Diff(field.Name, added, removed));
+                        diffs.Add(new Diff(field.Name, added, removed));
                     }
                 }
                 catch (InvalidCastException e)

--- a/Lib/Collectors/FileSystemCollector.cs
+++ b/Lib/Collectors/FileSystemCollector.cs
@@ -34,34 +34,39 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
 
             if (!Roots.Any())
             {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                Roots.AddRange(GetDefaultRoots());
+            }
+        }
+
+        public static IEnumerable<string> GetDefaultRoots()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                foreach (var driveInfo in DriveInfo.GetDrives())
                 {
-                    foreach (var driveInfo in DriveInfo.GetDrives())
+                    if (driveInfo.IsReady && driveInfo.DriveType == DriveType.Fixed)
                     {
-                        if (driveInfo.IsReady && driveInfo.DriveType == DriveType.Fixed)
-                        {
-                            Roots.Add(driveInfo.Name);
-                        }
+                        yield return driveInfo.Name;
                     }
                 }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                foreach (var directory in Directory.EnumerateDirectories("/"))
                 {
-                    foreach (var directory in Directory.EnumerateDirectories("/"))
+                    if (!directory.Equals("/proc") && !directory.Equals("/sys"))
                     {
-                        if (!directory.Equals("/proc") && !directory.Equals("/sys"))
-                        {
-                            Roots.Add(directory);
-                        }
-                        else
-                        {
-                            Log.Debug("Default settings skip directories /proc and /sys because they tend to have non-files which stall the collector.");
-                        }
+                        yield return directory;
+                    }
+                    else
+                    {
+                        Log.Debug("Default settings skip directories /proc and /sys because they tend to have non-files which stall the collector.");
                     }
                 }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    Roots.Add("/");
-                }
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                yield return "/";
             }
         }
 

--- a/Lib/Collectors/FileSystemMonitor.cs
+++ b/Lib/Collectors/FileSystemMonitor.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
                 GatherHashes = options.GatherHashes,
             });
 
-            foreach (var dir in (options.MonitoredDirectories.Any() is true) ? options.MonitoredDirectories : fsc.Roots.ToList())
+            foreach (var dir in (options.MonitoredDirectories.Any() is true) ? options.MonitoredDirectories : FileSystemCollector.GetDefaultRoots())
             {
                 foreach (var filter in defaultFiltersList)
                 {

--- a/Lib/Collectors/FileSystemMonitor.cs
+++ b/Lib/Collectors/FileSystemMonitor.cs
@@ -54,7 +54,6 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
             {
                 var ToWrite = new FileMonitorObject(e.Value.FullPath)
                 {
-                    ResultType = RESULT_TYPE.FILEMONITOR,
                     ChangeType = ChangeTypeStringToChangeType(e.Value.ChangeType.ToString()),
                     Name = e.Value.Name,
                     Timestamp = DateTime.Now.ToString("O", CultureInfo.InvariantCulture),
@@ -246,7 +245,6 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
                     var fso = (objIn.ChangeType == WatcherChangeTypes.Deleted || options.FileNamesOnly) ? null : fsc.FilePathToFileSystemObject(objIn.FullPath);
                     var ToWrite = new FileMonitorObject(objIn.FullPath)
                     {
-                        ResultType = RESULT_TYPE.FILEMONITOR,
                         ChangeType = ChangeTypeStringToChangeType(objIn.ChangeType.ToString()),
                         Name = objIn.Name,
                         Timestamp = DateTime.Now.ToString("O", CultureInfo.InvariantCulture),
@@ -312,7 +310,6 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
 
             var ToWrite = new FileMonitorObject(objIn.FullPath)
             {
-                ResultType = RESULT_TYPE.FILEMONITOR,
                 ChangeType = ChangeTypeStringToChangeType(objIn.ChangeType.ToString()),
                 OldPath = objIn.OldFullPath,
                 Name = objIn.Name,

--- a/Lib/Collectors/RegistryCollector.cs
+++ b/Lib/Collectors/RegistryCollector.cs
@@ -24,10 +24,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
                 throw new PlatformNotSupportedException("ExecuteWindows is only supported on Windows platforms.");
             }
             this.opts = opts ?? this.opts;
-            Hives = new List<(RegistryHive, string)>()
-            {
-                (RegistryHive.ClassesRoot,string.Empty), (RegistryHive.CurrentConfig,string.Empty), (RegistryHive.CurrentUser,string.Empty), (RegistryHive.LocalMachine,string.Empty), (RegistryHive.Users,string.Empty)
-            };
+            Hives = GetDefaultHivePairs().ToList();
             if (opts != null)
             {
                 Parallelize = !opts.SingleThread;
@@ -47,7 +44,22 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
                     }
                 }
             }
+        }
 
+        static IEnumerable<(RegistryHive hive, string path)> GetDefaultHivePairs()
+        {
+            foreach (var hive in Enum.GetValues<RegistryHive>())
+            {
+                yield return (hive, string.Empty);
+            }
+        }
+
+        public static IEnumerable<string> GetDefaultHives()
+        {
+            foreach(var hive in GetDefaultHivePairs())
+            {
+                yield return hive.hive.ToString();
+            }
         }
 
         public override bool CanRunOnPlatform()

--- a/Lib/Lib.csproj
+++ b/Lib/Lib.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="MedallionShell" Version="1.6.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.5" />
+    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.6" />
     <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="CompareNETObjects" Version="4.73.0" />

--- a/Lib/Lib.csproj
+++ b/Lib/Lib.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="MedallionShell" Version="1.6.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.6" />
+    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.9" />
     <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="CompareNETObjects" Version="4.73.0" />

--- a/Lib/Lib.csproj
+++ b/Lib/Lib.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="MedallionShell" Version="1.6.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.4" />
+    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.5" />
     <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="CompareNETObjects" Version="4.73.0" />

--- a/Lib/Lib.csproj
+++ b/Lib/Lib.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="MedallionShell" Version="1.6.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.11" />
+    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.12" />
     <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="CompareNETObjects" Version="4.73.0" />

--- a/Lib/Lib.csproj
+++ b/Lib/Lib.csproj
@@ -35,9 +35,9 @@
 
   <ItemGroup>
     <PackageReference Include="MedallionShell" Version="1.6.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.10.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
-    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.4" />
     <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="CompareNETObjects" Version="4.73.0" />

--- a/Lib/Lib.csproj
+++ b/Lib/Lib.csproj
@@ -37,11 +37,11 @@
     <PackageReference Include="MedallionShell" Version="1.6.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
-    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.3" />
     <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="CompareNETObjects" Version="4.73.0" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.8" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.9" />
     <PackageReference Include="Microsoft.PowerShell.Commands.Diagnostics" Version="7.1.3" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.1.3" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />

--- a/Lib/Lib.csproj
+++ b/Lib/Lib.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="MedallionShell" Version="1.6.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.10" />
+    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.11" />
     <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="CompareNETObjects" Version="4.73.0" />

--- a/Lib/Lib.csproj
+++ b/Lib/Lib.csproj
@@ -37,13 +37,13 @@
     <PackageReference Include="MedallionShell" Version="1.6.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.12" />
+    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.13" />
     <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="CompareNETObjects" Version="4.73.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.9" />
-    <PackageReference Include="Microsoft.PowerShell.Commands.Diagnostics" Version="7.1.3" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.1.3" />
+    <PackageReference Include="Microsoft.PowerShell.Commands.Diagnostics" Version="7.1.4" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.1.4" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/Lib/Lib.csproj
+++ b/Lib/Lib.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="MedallionShell" Version="1.6.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.9" />
+    <PackageReference Include="Microsoft.CST.OAT" Version="1.1.10" />
     <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="CompareNETObjects" Version="4.73.0" />

--- a/Lib/Objects/AsaRule.cs
+++ b/Lib/Objects/AsaRule.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CST.AttackSurfaceAnalyzer.Types;
 using Microsoft.CST.OAT;
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
@@ -16,11 +17,10 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
         {
             get
             {
-                return _flag;
+                return (ANALYSIS_RESULT_TYPE)Severity;
             }
             set
             {
-                _flag = value;
                 Severity = (int)value;
             }
         }
@@ -39,8 +39,6 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
                 Target = ResultTypeToTargetName(value);
             }
         }
-
-        private ANALYSIS_RESULT_TYPE _flag;
 
         private RESULT_TYPE _resultType;
 

--- a/Lib/Objects/CertificateObject.cs
+++ b/Lib/Objects/CertificateObject.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
             this.StoreLocation = StoreLocation;
             this.StoreName = StoreName;
             this.Certificate = Certificate;
-            ResultType = RESULT_TYPE.CERTIFICATE;
         }
+        public override RESULT_TYPE ResultType => RESULT_TYPE.CERTIFICATE;
 
         /// <summary>
         ///     A serializable representation of the Certificate.

--- a/Lib/Objects/CollectObject.cs
+++ b/Lib/Objects/CollectObject.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
     public abstract class CollectObject
     {
         public abstract string Identity { get; }
-        public RESULT_TYPE ResultType { get; set; }
+        public abstract RESULT_TYPE ResultType { get; }
 
         [SkipCompare]
         [JsonIgnore]

--- a/Lib/Objects/ComObject.cs
+++ b/Lib/Objects/ComObject.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
         public ComObject(RegistryObject Key) : base()
         {
             this.Key = Key;
-            ResultType = RESULT_TYPE.COM;
         }
+        public override RESULT_TYPE ResultType => RESULT_TYPE.COM;
 
         /// <summary>
         ///     A COM Object's identity is the same as the Registry Key which specifies it

--- a/Lib/Objects/CommandOptions.cs
+++ b/Lib/Objects/CommandOptions.cs
@@ -221,6 +221,11 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer
         public string? RunId { get; set; }
     }
 
+    [Verb("export-guided", HelpText = "Output a .json for a guided run")]
+    public class ExportGuidedCommandOptions : ExportMonitorCommandOptions
+    {
+    }
+
     public class ExportOptions : CommandOptions
     {
         [Option("filename", HelpText = "Custom analysis rules file.")]

--- a/Lib/Objects/CryptographicKeyObject.cs
+++ b/Lib/Objects/CryptographicKeyObject.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.CST.AttackSurfaceAnalyzer.Types;
 using Newtonsoft.Json;
+using Serilog;
 using System;
 using System.Security.Cryptography;
 using Tpm2Lib;
@@ -65,13 +66,20 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
         public RsaKeyDetails(string? PublicString = null, string? FullString = null)
         {
             rsa = RSA.Create();
-            if (FullString != null)
+            try
             {
-                rsa.ImportRSAPrivateKey(Convert.FromBase64String(FullString), out _);
+                if (FullString != null)
+                {
+                    rsa.ImportRSAPrivateKey(Convert.FromBase64String(FullString), out _);
+                }
+                else if (PublicString != null)
+                {
+                    rsa.ImportRSAPublicKey(Convert.FromBase64String(PublicString), out _);
+                }
             }
-            else if (PublicString != null)
+            catch(Exception e)
             {
-                rsa.ImportRSAPublicKey(Convert.FromBase64String(PublicString), out _);
+                Log.Debug(e, "Failed to import RSA key.");
             }
         }
 

--- a/Lib/Objects/CryptographicKeyObject.cs
+++ b/Lib/Objects/CryptographicKeyObject.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License.
 
+using Microsoft.CST.AttackSurfaceAnalyzer.Types;
 using Newtonsoft.Json;
 using System;
 using System.Security.Cryptography;
@@ -11,10 +12,11 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
     {
         public CryptographicKeyObject(string Source, TpmAlgId tpmAlgId)
         {
-            this.ResultType = Types.RESULT_TYPE.KEY;
             this.Source = Source;
             this.tpmAlgId = tpmAlgId;
         }
+
+        public override RESULT_TYPE ResultType => RESULT_TYPE.KEY;
 
         public override string Identity
         {

--- a/Lib/Objects/DriverObject.cs
+++ b/Lib/Objects/DriverObject.cs
@@ -10,9 +10,8 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
         public DriverObject(string Name)
         {
             this.Name = Name;
-            ResultType = RESULT_TYPE.DRIVER;
         }
-
+        public override RESULT_TYPE ResultType => RESULT_TYPE.DRIVER;
         public bool? AcceptPause { get; set; }
         public bool? AcceptStop { get; set; }
         public string? Address { get; set; }

--- a/Lib/Objects/EventLogObject.cs
+++ b/Lib/Objects/EventLogObject.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License.
+using Microsoft.CST.AttackSurfaceAnalyzer.Types;
 using System;
 using System.Collections.Generic;
 
@@ -9,9 +10,9 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
         public EventLogObject(string Event)
         {
             this.Event = Event;
-            ResultType = Types.RESULT_TYPE.LOG;
             Data = new List<string>();
         }
+        public override RESULT_TYPE ResultType => RESULT_TYPE.LOG;
 
         /// <summary>
         ///     Additional associated data

--- a/Lib/Objects/FileMonitorObject.cs
+++ b/Lib/Objects/FileMonitorObject.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
         public FileMonitorObject(string PathIn)
         {
             Path = PathIn;
-            ResultType = RESULT_TYPE.FILEMONITOR;
         }
+        public override RESULT_TYPE ResultType => RESULT_TYPE.FILEMONITOR;
 
         public string? ExtendedResults { get; set; }
         public FileSystemObject? FileSystemObject { get; set; }

--- a/Lib/Objects/FileSystemObject.cs
+++ b/Lib/Objects/FileSystemObject.cs
@@ -10,14 +10,14 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
         public FileSystemObject(string Path)
         {
             this.Path = Path;
-            ResultType = RESULT_TYPE.FILE;
         }
 
         public FileSystemObject()
         {
             Path = string.Empty;
-            ResultType = RESULT_TYPE.FILE;
         }
+
+        public override RESULT_TYPE ResultType => RESULT_TYPE.FILE;
 
         /// <summary>
         ///     If this is windows executable what DLL Characteristics are set

--- a/Lib/Objects/FirewallObject.cs
+++ b/Lib/Objects/FirewallObject.cs
@@ -9,9 +9,11 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
     {
         public FirewallObject(string Name)
         {
-            ResultType = RESULT_TYPE.FIREWALL;
             this.Name = Name;
         }
+
+        public override RESULT_TYPE ResultType => RESULT_TYPE.FIREWALL;
+
 
         /// <summary>
         ///     Gets or sets the action that the rules defines

--- a/Lib/Objects/OpenPortObject.cs
+++ b/Lib/Objects/OpenPortObject.cs
@@ -11,11 +11,12 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
 
         public OpenPortObject(int Port, TRANSPORT Type, ADDRESS_FAMILY AddressFamily)
         {
-            ResultType = RESULT_TYPE.PORT;
             this.Port = Port;
             this.Type = Type;
             this.AddressFamily = AddressFamily;
         }
+
+        public override RESULT_TYPE ResultType => RESULT_TYPE.PORT;
 
         public string? Address { get; set; }
 

--- a/Lib/Objects/ProcessObject.cs
+++ b/Lib/Objects/ProcessObject.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License.
+using Microsoft.CST.AttackSurfaceAnalyzer.Types;
 using Serilog;
 using System;
 using System.Collections.Generic;
@@ -12,8 +13,9 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
         {
             this.Id = Id;
             this.ProcessName = ProcessName;
-            ResultType = Types.RESULT_TYPE.PROCESS;
         }
+
+        public override RESULT_TYPE ResultType => RESULT_TYPE.PROCESS;
 
         public int BasePriority { get; set; }
 

--- a/Lib/Objects/RegistryObject.cs
+++ b/Lib/Objects/RegistryObject.cs
@@ -11,10 +11,11 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
     {
         public RegistryObject(string Key, RegistryView View)
         {
-            ResultType = RESULT_TYPE.REGISTRY;
             this.View = View;
             this.Key = Key;
         }
+
+        public override RESULT_TYPE ResultType => RESULT_TYPE.REGISTRY;
 
         public override string Identity
         {

--- a/Lib/Objects/ServiceObject.cs
+++ b/Lib/Objects/ServiceObject.cs
@@ -11,8 +11,8 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
         public ServiceObject(string Name)
         {
             this.Name = Name;
-            ResultType = RESULT_TYPE.SERVICE;
         }
+        public override RESULT_TYPE ResultType => RESULT_TYPE.SERVICE;
 
         public bool? AcceptPause { get; set; }
         public bool? AcceptStop { get; set; }

--- a/Lib/Objects/TpmObject.cs
+++ b/Lib/Objects/TpmObject.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License.
+using Microsoft.CST.AttackSurfaceAnalyzer.Types;
 using System;
 using System.Collections.Generic;
 using Tpm2Lib;
@@ -9,9 +10,9 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
     {
         public TpmObject(string Location)
         {
-            ResultType = Types.RESULT_TYPE.TPM;
             this.Location = Location;
         }
+        public override RESULT_TYPE ResultType => RESULT_TYPE.TPM;
 
         public List<AlgProperty> Algorithms { get; set; } = new List<AlgProperty>();
         public List<TpmCc> Commands { get; set; } = new List<TpmCc>();

--- a/Lib/Objects/UserAccountObject.cs
+++ b/Lib/Objects/UserAccountObject.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
         public UserAccountObject(string Name)
         {
             this.Name = Name;
-            ResultType = RESULT_TYPE.USER;
         }
+        public override RESULT_TYPE ResultType => RESULT_TYPE.USER;
 
         public string? AccountType { get; set; }
         public string? Caption { get; set; }

--- a/Lib/Objects/UserGroupObject.cs
+++ b/Lib/Objects/UserGroupObject.cs
@@ -9,8 +9,8 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
         public GroupAccountObject(string Name)
         {
             this.Name = Name;
-            ResultType = RESULT_TYPE.GROUP;
         }
+        public override RESULT_TYPE ResultType => RESULT_TYPE.GROUP;
 
         public string? Caption { get; set; }
         public string? Description { get; set; }

--- a/Lib/Objects/WifiObject.cs
+++ b/Lib/Objects/WifiObject.cs
@@ -1,12 +1,15 @@
-﻿namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
+﻿using Microsoft.CST.AttackSurfaceAnalyzer.Types;
+
+namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
 {
     public class WifiObject : CollectObject
     {
         public WifiObject(string SSID)
         {
             this.SSID = SSID;
-            this.ResultType = Types.RESULT_TYPE.WIFI;
         }
+
+        public override RESULT_TYPE ResultType => RESULT_TYPE.WIFI;
 
         public string? Authentication { get; set; }
 

--- a/Lib/Properties/Resources.resx
+++ b/Lib/Properties/Resources.resx
@@ -600,4 +600,7 @@
   <data name="Err_DatabaseManagerNull" xml:space="preserve">
     <value>DatabaseManager is null at execution of {0}.</value>
   </data>
+  <data name="Err_RunIdNull" xml:space="preserve">
+    <value>The provided RunId was null.</value>
+  </data>
 </root>

--- a/Lib/Utils/SqliteDatabaseManager.cs
+++ b/Lib/Utils/SqliteDatabaseManager.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License.
+using Microsoft.CST.AttackSurfaceAnalyzer.Collectors;
 using Microsoft.CST.AttackSurfaceAnalyzer.Objects;
 using Microsoft.CST.AttackSurfaceAnalyzer.Types;
 using Microsoft.CST.OAT.Operations;
@@ -326,6 +327,10 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Utils
                             if (reader["second_serialized"] is string second_serialized)
                             {
                                 obj.Compare = JsonUtils.Hydrate(second_serialized, (RESULT_TYPE)resultType);
+                            }
+                            if (obj.Base is not null && obj.Compare is not null)
+                            {
+                                obj.Diffs = BaseCompare.GenerateDiffs(obj.Base, obj.Compare);
                             }
 
                             results.Add(obj);

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
   </ItemGroup>

--- a/analyses.json
+++ b/analyses.json
@@ -7,7 +7,7 @@
       "ResultType": "PORT",
       "Clauses": [
         {
-          "Field": "port",
+          "Field": "Port",
           "Operation": "LessThan",
           "Data": [
             "1024"
@@ -402,7 +402,7 @@
       "ResultType": "PORT",
       "Clauses": [
         {
-          "Field": "port",
+          "Field": "Port",
           "Operation": "Equals",
           "Data": [
             "1900"

--- a/analyses.json
+++ b/analyses.json
@@ -116,46 +116,6 @@
       ]
     },
     {
-      "Name": "SetGid",
-      "Description": "Flag GID is set on a file.",
-      "Flag": "WARNING",
-      "Platforms": [
-        "LINUX",
-        "MACOS"
-      ],
-      "ChangeTypes": [
-        "CREATED",
-        "MODIFIED"
-      ],
-      "ResultType": "FILE",
-      "Clauses": [
-        {
-          "Field": "SetGid",
-          "Operation": "IsTrue"
-        }
-      ]
-    },
-    {
-      "Name": "SetGid",
-      "Description": "Flag GID is set on a file.",
-      "Flag": "WARNING",
-      "Platforms": [
-        "LINUX",
-        "MACOS"
-      ],
-      "ChangeTypes": [
-        "CREATED",
-        "MODIFIED"
-      ],
-      "ResultType": "FILEMONITOR",
-      "Clauses": [
-        {
-          "Field": "FileSystemObject.SetGid",
-          "Operation": "IsTrue"
-        }
-      ]
-    },
-    {
       "Name": "SetUid",
       "Description": "Flag UID is set on a file.",
       "Flag": "WARNING",
@@ -191,6 +151,26 @@
       "Clauses": [
         {
           "Field": "SetGid",
+          "Operation": "IsTrue"
+        }
+      ]
+    },
+    {
+      "Name": "SetGid",
+      "Description": "Flag GID is set on a file.",
+      "Flag": "WARNING",
+      "Platforms": [
+        "LINUX",
+        "MACOS"
+      ],
+      "ChangeTypes": [
+        "CREATED",
+        "MODIFIED"
+      ],
+      "ResultType": "FILEMONITOR",
+      "Clauses": [
+        {
+          "Field": "FileSystemObject.SetGid",
           "Operation": "IsTrue"
         }
       ]

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.3-beta",
+  "version": "2.3",
   "versionHeightOffset": "256",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
Adds Exporting from the GUI.
Populate default paths for registry and file collector to make it clear what will happen.
Improve the scanning state output to update properly.
Scanning modes are now exclusive and will prevent you from starting a different kind of scan.
Scanning modes will now keep track of what state they were in the appData object so you can return to them if you leave the page.