### PR TITLE
Add Additional Logging for #638

### DIFF
--- a/Cli/AttackSurfaceAnalyzerClient.cs
+++ b/Cli/AttackSurfaceAnalyzerClient.cs
@@ -1156,7 +1156,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
                 if (opts.AnalysesFile is not null)
                 {
                     watch = Stopwatch.StartNew();
-                    var analyzer = new AsaAnalyzer(new AnalyzerOptions(opts.RunScripts));
+                    var analyzer = new AsaAnalyzer(new AnalyzerOptions(opts.RunScripts, !opts.SingleThreadAnalysis));
                     var platform = DatabaseManager.RunIdToPlatform(opts.SecondRunId);
                     var violations = analyzer.EnumerateRuleIssues(opts.AnalysesFile.Rules);
                     var analysesHash = opts.AnalysesFile.GetHash();
@@ -1168,14 +1168,26 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
                     }
                     else
                     {
-                        if (c.Results.Count > 0)
+                        if (!c.Results.IsEmpty)
                         {
-                            foreach (var key in c.Results.Keys)
+                            foreach ((RESULT_TYPE, CHANGE_TYPE) key in c.Results.Keys)
                             {
                                 if (c.Results[key] is List<CompareResult> queue)
                                 {
-                                    var platformRules = opts.AnalysesFile.Rules.Where(rule => rule.Platforms == null || rule.Platforms.Contains(platform));
-                                    queue.AsParallel().ForAll(res =>
+                                    IEnumerable<AsaRule> platformRules = opts.AnalysesFile.Rules.Where(rule => rule.Platforms == null || rule.Platforms.Contains(platform));
+                                    if (opts.SingleThreadAnalysis)
+                                    {
+                                        foreach(CompareResult res in queue)
+                                        {
+                                            PopulateAnalysisForResult(res);
+                                        }
+                                    }
+                                    else
+                                    {
+                                        queue.AsParallel().ForAll(PopulateAnalysisForResult);
+                                    }
+
+                                    void PopulateAnalysisForResult(CompareResult res)
                                     {
                                         // Select rules with the appropriate change type and target (ResultType)
                                         // - Target is also checked inside Analyze, but this shortcuts repeatedly
@@ -1183,11 +1195,24 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
                                         var selectedRules = platformRules.Where((rule) =>
                                             (rule.ChangeTypes == null || rule.ChangeTypes.Contains(res.ChangeType))
                                                 && (rule.ResultType == res.ResultType));
-                                        res.Rules = analyzer.Analyze(selectedRules, res.Base, res.Compare).ToList();
+                                        Log.Verbose("Type: {0}", res.ResultType);
+                                        Log.Verbose("Base: {0}", JsonConvert.SerializeObject(res.Base));
+                                        Log.Verbose("Compare: {0}", JsonConvert.SerializeObject(res.Compare));
+                                        Log.Verbose("Num Rules: {0}", selectedRules.Count());
+                                        try 
+                                        {
+                                            res.Rules = analyzer.Analyze(selectedRules, res.Base, res.Compare).ToList();
+                                        }
+                                        catch(Exception ex)
+                                        {
+                                            Log.Debug("Exception while analyzing object {3}. Use --verbose for object details. {0}:{1}. {2}.", ex.GetType().Name, ex.Message, ex.StackTrace, res.Identity);
+                                        }
+                                        Log.Verbose("Applied Rules: {0}", res.Rules);
+
                                         res.Analysis = res.Rules.Count
-                                                       > 0 ? res.Rules.Max(x => ((AsaRule)x).Flag) : opts.AnalysesFile.GetDefaultLevel(res.ResultType);
+                                                        > 0 ? res.Rules.Max(x => ((AsaRule)x).Flag) : opts.AnalysesFile.GetDefaultLevel(res.ResultType);
                                         res.AnalysesHash = analysesHash;
-                                    });
+                                    };
                                 }
                             }
                         }

--- a/Cli/AttackSurfaceAnalyzerClient.cs
+++ b/Cli/AttackSurfaceAnalyzerClient.cs
@@ -186,7 +186,8 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
                 ExplodedOutput = opts.ExplodedOutput,
                 OutputSarif = opts.ExportSarif,
                 OutputPath = opts.OutputPath,
-                ApplySubObjectRulesToMonitor = opts.ApplySubObjectRulesToMonitor
+                ApplySubObjectRulesToMonitor = opts.ApplySubObjectRulesToMonitor,
+                SingleThreadAnalysis = opts.SingleThreadAnalysis
             };
             var first = GuidedRunIdToFirstCollectRunId(opts.RunId);
             var second = GuidedRunIdToSecondCollectRunId(opts.RunId);
@@ -282,7 +283,8 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
             {
                 DisableAnalysis = opts.DisableAnalysis,
                 AnalysesFile = analysisFile,
-                RunScripts = opts.RunScripts
+                RunScripts = opts.RunScripts,
+                SingleThreadAnalysis = opts.SingleThreadAnalysis
             };
 
             var results = CompareRuns(compareOpts);
@@ -297,7 +299,8 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
                 DisableAnalysis = opts.DisableAnalysis,
                 AnalysesFile = analysisFile,
                 ApplySubObjectRulesToMonitor = opts.ApplySubObjectRulesToMonitor,
-                RunScripts = opts.RunScripts
+                RunScripts = opts.RunScripts,
+                SingleThreadAnalysis = opts.SingleThreadAnalysis
             };
 
             var monitorResult = AnalyzeMonitored(monitorCompareOpts);
@@ -610,7 +613,8 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
                 AnalysesFile = ruleFile,
                 DisableAnalysis = opts.DisableAnalysis,
                 SaveToDatabase = opts.SaveToDatabase,
-                RunScripts = opts.RunScripts
+                RunScripts = opts.RunScripts,
+                SingleThreadAnalysis = opts.SingleThreadAnalysis
             };
 
             var results = CompareRuns(options);
@@ -939,7 +943,8 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
                 DisableAnalysis = opts.DisableAnalysis,
                 AnalysesFile = ruleFile,
                 ApplySubObjectRulesToMonitor = opts.ApplySubObjectRulesToMonitor,
-                RunScripts = opts.RunScripts
+                RunScripts = opts.RunScripts,
+                SingleThreadAnalysis = opts.SingleThreadAnalysis
             };
 
             var monitorResult = AnalyzeMonitored(monitorCompareOpts);

--- a/Cli/Pages/_Layout.cshtml
+++ b/Cli/Pages/_Layout.cshtml
@@ -1,0 +1,36 @@
+﻿@using Microsoft.AspNetCore.Components.Web
+@namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@{
+    Layout = null;
+}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Attack Surface Analyzer</title>
+    <base href="~/" />
+    <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
+    <link rel="stylesheet" href="css/asa.css" />
+    <script src="~/js/jquery-3.5.1.slim.min.js"></script>
+    <script src="~/js/bootstrap.bundle.min.js"></script>
+</head>
+<body>
+    @RenderBody()
+
+    <div id="blazor-error-ui">
+        <environment include="Staging,Production">
+            An error has occurred. This application may no longer respond until reloaded.
+        </environment>
+        <environment include="Development">
+            An unhandled exception has occurred. See browser dev tools for details.
+        </environment>
+        <a href="" class="reload">Reload</a>
+        <a class="dismiss">🗙</a>
+    </div>
+
+    <script src="_framework/blazor.server.js"></script>
+</body>
+</html>

--- a/Cli/Properties/launchSettings.json
+++ b/Cli/Properties/launchSettings.json
@@ -3,36 +3,26 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:50108",
-      "sslPort": 0
+      "applicationUrl": "http://localhost:61357",
+      "sslPort": 44392
     }
   },
   "profiles": {
-    "IIS Express": {
+    "BlazorApp1": {
       "commandName": "Project",
-      "commandLineArgs": "gui",
+      "dotnetRunMessages": true,
       "launchBrowser": true,
+      "applicationUrl": "https://localhost:7280;http://localhost:5280",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "Blazor": {
+    "IIS Express": {
       "commandName": "IISExpress",
-      "commandLineArgs": "gui --nolaunch",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:5000"
-    },
-    "Microsoft.CST.AttackSurfaceAnalyzer.Cli": {
-      "commandName": "Project",
-      "commandLineArgs": "gui",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:46312"
+      }
     }
   }
 }

--- a/Cli/Properties/launchSettings.json
+++ b/Cli/Properties/launchSettings.json
@@ -8,21 +8,22 @@
     }
   },
   "profiles": {
-    "BlazorApp1": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:7280;http://localhost:5280",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    },
+    "ASA GUI": {
+      "commandName": "Project",
+      "commandLineArgs": "gui",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:7280;http://localhost:5280",
+      "dotnetRunMessages": true
     }
   }
 }

--- a/Lib/Objects/CommandOptions.cs
+++ b/Lib/Objects/CommandOptions.cs
@@ -251,6 +251,9 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer
 
         [Option(HelpText = "Output Sarif")]
         public bool OutputSarif { get; set; }
+
+        [Option(HelpText = "Force Analysis to be Single-Threaded")]
+        public bool SingleThreadAnalysis { get; set; }
     }
 
     [Verb("gui", HelpText = "Launch the GUI in a browser.")]
@@ -300,6 +303,9 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer
 
         [Option(HelpText = "Export Sarif")]
         public bool ExportSarif { get; set; }
+
+        [Option(HelpText = "Force Analysis to be Single-Threaded")]
+        public bool SingleThreadAnalysis { get; set; }
     }
 
     [Verb("monitor", HelpText = "Continue running and monitor activity")]

--- a/Lib/Objects/CommandOptions.cs
+++ b/Lib/Objects/CommandOptions.cs
@@ -180,6 +180,9 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer
 
         [Option(HelpText = "Run Scripts")]
         public bool RunScripts { get; set; }
+
+        [Option(HelpText = "Force Analysis to be Single-Threaded")]
+        public bool SingleThreadAnalysis { get; set; }
     }
 
     [Verb("config", HelpText = "Configure and query the database")]


### PR DESCRIPTION
To help debug #638 this adds additional logging and a catch in the area with the crash.  Running this version with --debug should give you more detailed information on the exception being thrown and --verbose will give you much more information on each object as it is analysed.

Also adds a --SingleThreadAnalysis option to force analysis to be run single threaded instead of in parallel (only recommended for debugging).