### PR TITLE
Fix #638

### DIFF
--- a/Cli/Components/States/Results.razor
+++ b/Cli/Components/States/Results.razor
@@ -195,7 +195,7 @@ else
     {
         if (AttackSurfaceAnalyzerClient.DatabaseManager is null) { return; }
         var iterationSize = 1000;
-        var results = new ConcurrentDictionary<(RESULT_TYPE, CHANGE_TYPE), List<CompareResult>>();
+        var results = new ConcurrentDictionary<(RESULT_TYPE, CHANGE_TYPE), ConcurrentBag<CompareResult>>();
         foreach(var resultType in foundResultTypes)
         {
             for (int i = 0; i < resultType.Value; i += iterationSize)
@@ -207,7 +207,7 @@ else
                         {
                             if (!results.ContainsKey((result.ResultType, result.ChangeType)))
                             {
-                                results[(result.ResultType, result.ChangeType)] = new List<CompareResult>();
+                                results[(result.ResultType, result.ChangeType)] = new ConcurrentBag<CompareResult>();
                             }
                             results[(result.ResultType, result.ChangeType)].Add(result);
                         }
@@ -217,7 +217,7 @@ else
                         {
                             if (!results.ContainsKey((result.ResultType, result.ChangeType)))
                             {
-                                results[(result.ResultType, result.ChangeType)] = new List<CompareResult>();
+                                results[(result.ResultType, result.ChangeType)] = new ConcurrentBag<CompareResult>();
                             }
                             results[(result.ResultType, result.ChangeType)].Add(result);
                         }

--- a/Cli/Properties/launchSettings.json
+++ b/Cli/Properties/launchSettings.json
@@ -24,6 +24,14 @@
       },
       "applicationUrl": "https://localhost:7280;http://localhost:5280",
       "dotnetRunMessages": true
+    },
+    "Export-collect last 2": {
+      "commandName": "Project",
+      "commandLineArgs": "export-collect"
+    },
+    "Export-monitor": {
+      "commandName": "Project",
+      "commandLineArgs": "export-monitor"
     }
   }
 }

--- a/Lib/Collectors/BaseCompare.cs
+++ b/Lib/Collectors/BaseCompare.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Tpm2Lib;
+using System.Diagnostics;
 
 namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
 {
@@ -21,20 +22,20 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
     {
         public BaseCompare()
         {
-            Results = new ConcurrentDictionary<(RESULT_TYPE, CHANGE_TYPE), List<CompareResult>>();
+            Results = new ConcurrentDictionary<(RESULT_TYPE, CHANGE_TYPE), ConcurrentBag<CompareResult>>();
             foreach (RESULT_TYPE? result_type in Enum.GetValues(typeof(RESULT_TYPE)))
             {
                 foreach (CHANGE_TYPE? change_type in Enum.GetValues(typeof(CHANGE_TYPE)))
                 {
                     if (result_type is RESULT_TYPE r && change_type is CHANGE_TYPE c)
                     {
-                        Results[(r, c)] = new List<CompareResult>();
+                        Results[(r, c)] = new ConcurrentBag<CompareResult>();
                     }
                 }
             }
         }
 
-        public ConcurrentDictionary<(RESULT_TYPE, CHANGE_TYPE), List<CompareResult>> Results { get; }
+        public ConcurrentDictionary<(RESULT_TYPE, CHANGE_TYPE), ConcurrentBag<CompareResult>> Results { get; }
 
         public void Compare(IEnumerable<CollectObject> FirstRunObjects, IEnumerable<CollectObject> SecondRunObjects, string? firstRunId, string secondRunId)
         {


### PR DESCRIPTION
During comparison results are stored in a ConcurrentDictionary keyed by object type which contains Lists. Lists are however, not threadsafe. This PR changes those lists to be concurrentbags which seems to resolve the issue.  I was only able to replicate this intermittently and only with very large data sets when the high thread count comes into play.