### PR TITLE
Adds configuration option for the notify filters that are used for FileSystemMonitor

### DIFF
--- a/Lib/Collectors/FileSystemMonitor.cs
+++ b/Lib/Collectors/FileSystemMonitor.cs
@@ -70,10 +70,12 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
         {
             return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         }
-
+        
         public FileSystemMonitor(MonitorCommandOptions opts, Action<FileMonitorObject> changeHandler)
         {
-            options = opts ?? new MonitorCommandOptions();
+            options = opts ?? new();
+            var filters = options.Filters.Any() ? options.Filters : defaultFiltersList;
+
             this.changeHandler = changeHandler ?? throw new NullReferenceException(nameof(changeHandler));
 
             fsc = new FileSystemCollector(new CollectorOptions()
@@ -84,7 +86,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
 
             foreach (var dir in (options.MonitoredDirectories.Any() is true) ? options.MonitoredDirectories : FileSystemCollector.GetDefaultRoots())
             {
-                foreach (var filter in defaultFiltersList)
+                foreach (var filter in filters)
                 {
                     var watcher = new FileSystemWatcher
                     {

--- a/Lib/Objects/CommandOptions.cs
+++ b/Lib/Objects/CommandOptions.cs
@@ -3,6 +3,8 @@ using CommandLine;
 using Microsoft.CST.AttackSurfaceAnalyzer.Objects;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace Microsoft.CST.AttackSurfaceAnalyzer
 {
@@ -333,6 +335,10 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer
 
         [Option(HelpText = "Identifies which run this is. Monitor output can be combined with collect output, but doesn't need to be compared.", Default = "Timestamp")]
         public string? RunId { get; set; }
+
+        [Option(HelpText =
+            "Specify which NotifyFilters to use for file monitoring, comma separated if provided via cli.", Separator = ',')]
+        public IEnumerable<NotifyFilters> Filters { get; set; } = Enumerable.Empty<NotifyFilters>();
     }
 
     [Verb("verify", HelpText = "Verify your analysis rules")]


### PR DESCRIPTION
The FileSystemMonitor was using a hardcoded set of [NotifyFilters](https://docs.microsoft.com/en-us/dotnet/api/system.io.notifyfilters?view=net-6.0). These can now be passed in, if you don't specify them you get the same behavior as before.