### PR TITLE
Gfs/649+652

### DIFF
--- a/Cli/AttackSurfaceAnalyzerClient.cs
+++ b/Cli/AttackSurfaceAnalyzerClient.cs
@@ -13,6 +13,7 @@ using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 using Serilog;
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -764,7 +765,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
 
             foreach (var item in results)
             {
-                var compareResults = (List<CompareResult>)item.Value;
+                var compareResults = (IEnumerable<CompareResult>)item.Value;
                 foreach (var compareResult in compareResults)
                 {
                     if (!artifacts.Any(a => a.Location.Description.Text.ToString() == compareResult.Identity))

--- a/Lib/Collectors/OpenPortCollector.cs
+++ b/Lib/Collectors/OpenPortCollector.cs
@@ -51,9 +51,11 @@ u_str LISTEN 0      4096                          /run/libvirt/virtlockd-sock 26
 Netid State  Recv-Q Send-Q                              Local Address:Port        Peer Address:PortProcess                                                          
 nl    UNCONN 0      0                                               0:530                     *                                                                     
 */
+        // See https://github.com/microsoft/AttackSurfaceAnalyzer/issues/649 for discussion on this regex and potential other solutions parsing sock files directly.
         private static Regex LinuxSsParsingRegex { get; } = new Regex(
-            "([\\S]+)\\s+([\\S]+)\\s+([\\S]+)\\s+([\\S]+)\\s+([\\S]+)[\\s+|:]([\\S]+)\\s+([\\S]+)(\\s+([\\S]+)\\s+([\\S]+))?",
-            RegexOptions.Compiled);
+            "^([\\S]+)\\s+([\\S]+)\\s+([\\S]+)\\s+([\\S]+)\\s+([\\S]+)[\\s:]([\\S]+)\\s+([\\S]+)(?:([\\s:]([\\S]+))?\\s+([\\S]+))?\\s*$",
+        RegexOptions.Compiled);
+        
         
         /// <summary>
         ///     Executes the OpenPortCollector on Linux. Calls out to the `ss` command and parses the output,


### PR DESCRIPTION
Fix #649 - update port collection regex for more cases on linux
Fix #652 - fix incorrect cast of concurrentbag to list.