### PR TITLE
Update NuGet to point to Azure Artifacts.

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear/>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>

--- a/NuGet.Config.AzureArtifacts
+++ b/NuGet.Config.AzureArtifacts
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="PublicRegistriesFeed" value="https://twcsecurityassurance.pkgs.visualstudio.com/SecurityEngineering/_packaging/PublicRegistriesFeed/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/Pipelines/templates/dotnet-publish-linux-mac-job.yml
+++ b/Pipelines/templates/dotnet-publish-linux-mac-job.yml
@@ -42,6 +42,7 @@ jobs:
   pool:
     vmImage: 'ubuntu-latest'
   steps:
+  - task: NuGetAuthenticate@1  
   - task: UseDotNet@2
     displayName: Install Dotnet SDK
     inputs:
@@ -56,6 +57,8 @@ jobs:
     displayName: Restore
     inputs:
       command: 'restore'
+      feedsToUse: config
+      nugetConfigPath: NuGet.Config.AzureArtifacts
       projects: ${{ parameters.projectPath }}
       verbosityRestore: 'Normal'
   - task: DotNetCoreCLI@2

--- a/Pipelines/templates/dotnet-publish-win-netcore-job.yml
+++ b/Pipelines/templates/dotnet-publish-win-netcore-job.yml
@@ -42,6 +42,7 @@ jobs:
   pool:
     vmImage: 'windows-latest'
   steps:
+  - task: NuGetAuthenticate@1  
   - task: UseDotNet@2
     displayName: Install Dotnet SDK
     inputs:
@@ -56,6 +57,8 @@ jobs:
     displayName: Restore
     inputs:
       command: 'restore'
+      feedsToUse: config
+      nugetConfigPath: NuGet.Config.AzureArtifacts
       projects: ${{ parameters.projectPath }}
       verbosityRestore: 'Normal'
   - task: DotNetCoreCLI@2

--- a/Pipelines/templates/dotnet-test-job.yml
+++ b/Pipelines/templates/dotnet-test-job.yml
@@ -22,6 +22,7 @@ jobs:
   pool:
     vmImage: 'windows-latest'
   steps:
+  - task: NuGetAuthenticate@1
   - task: UseDotNet@2
     displayName: Install Dotnet SDK
     inputs:
@@ -35,6 +36,8 @@ jobs:
     displayName: Dotnet Restore
     inputs:
       command: 'restore'
+      feedsToUse: config
+      nugetConfigPath: NuGet.Config.AzureArtifacts
       projects: ${{ parameters.projectPath }}
       verbosityRestore: 'Normal'
   - task: DotNetCoreCLI@2

--- a/Pipelines/templates/nuget-build-job.yml
+++ b/Pipelines/templates/nuget-build-job.yml
@@ -34,6 +34,7 @@ jobs:
   pool:
     vmImage: 'windows-latest'
   steps:
+  - task: NuGetAuthenticate@1  
   - task: UseDotNet@2
     displayName: Install Dotnet SDK
     inputs:
@@ -47,6 +48,8 @@ jobs:
     displayName: Dotnet Restore
     inputs:
       command: 'restore'
+      feedsToUse: config
+      nugetConfigPath: NuGet.Config.AzureArtifacts
       projects: ${{ parameters.projectPath }}
       verbosityRestore: 'Normal'
   - task: DotNetCoreCLI@2


### PR DESCRIPTION
This PR removes the dependency on public nuget.org in favor of an authenticated feed via Azure Artifacts. Public users who won't have access to this feed would pull packages from nuget.org, so there shouldn't be any change to anyone's experience.