### PR TITLE
Fixes some reported issues

### DIFF
--- a/Cli/AttackSurfaceAnalyzerClient.cs
+++ b/Cli/AttackSurfaceAnalyzerClient.cs
@@ -257,11 +257,6 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
                     results[kvp.Key] = new ConcurrentBag<CompareResult>(kvp.Value.Where(x => opts.ResultLevels.Contains(x.Analysis)));
                 }
             }
-            if (opts.SaveToDatabase)
-            {
-                InsertCompareResults(results, first, second, analysesHash);
-            }
-
             var exportOptions = new ExportOptions()
             {
                 OutputSarif = opts.OutputSarif,
@@ -1002,18 +997,19 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
             };
 
             var monitorResult = AnalyzeMonitored(monitorCompareOpts);
+            
+            var analysesHash = monitorCompareOpts.AnalysesFile.GetHash();
+
+            if (opts.SaveToDatabase)
+            {
+                InsertCompareResults(monitorResult, null, opts.RunId, analysesHash);
+            }
             if (opts.ResultLevels.Any())
             {
                 foreach (var kvp in monitorResult)
                 {
                     monitorResult[kvp.Key] = new ConcurrentBag<CompareResult>(kvp.Value.Where(x => opts.ResultLevels.Contains(x.Analysis)));
                 }
-            }
-            var analysesHash = monitorCompareOpts.AnalysesFile.GetHash();
-
-            if (opts.SaveToDatabase)
-            {
-                InsertCompareResults(monitorResult, null, opts.RunId, analysesHash);
             }
 
             return ExportCompareResults(monitorResult, opts, AsaHelpers.MakeValidFileName(opts.RunId), analysesHash, ruleFile.Rules);

--- a/Cli/AttackSurfaceAnalyzerClient.cs
+++ b/Cli/AttackSurfaceAnalyzerClient.cs
@@ -787,61 +787,56 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
                 var compareResults = (IEnumerable<CompareResult>)item.Value;
                 foreach (var compareResult in compareResults)
                 {
-                    if (!artifacts.Any(a => a.Location.Description.Text.ToString() == compareResult.Identity))
+                    var artifact = new Artifact
                     {
-                        var artifact = new Artifact
+                        Location = new ArtifactLocation()
                         {
-                            Location = new ArtifactLocation()
-                            {
-                                Index = artifacts.Count,
-                                Description = new Message() { Text = compareResult.Identity }
-                            }
-                        };
-
-                        if (Uri.TryCreate(compareResult.Identity, UriKind.RelativeOrAbsolute, out Uri? outUri))
-                        {
-                            artifact.Location.Uri = outUri;
+                            Index = artifacts.Count,
+                            Description = new Message() { Text = compareResult.Identity }
                         }
+                    };
 
-                        artifact.SetProperty("Analysis", compareResult.Analysis.ToString());
-
-                        if (compareResult.Base != null)
-                        {
-                            artifact.SetProperty("Base", compareResult.Base);
-                        }
-
-                        if (!string.IsNullOrWhiteSpace(compareResult.BaseRunId))
-                        {
-                            artifact.SetProperty("BaseRunId", compareResult.BaseRunId.ToString());
-                        }
-
-                        artifact.SetProperty("ChangeType", compareResult.ChangeType.ToString());
-
-                        if (compareResult.Compare != null)
-                        {
-                            artifact.SetProperty("Compare", compareResult.Compare);
-                        }
-
-                        if (!string.IsNullOrWhiteSpace(compareResult.CompareRunId))
-                        {
-                            artifact.SetProperty("CompareRunId", compareResult.CompareRunId);
-                        }
-
-                        if (compareResult.Diffs != null && compareResult.Diffs.Count > 0)
-                        {
-                            artifact.SetProperty("Diffs", compareResult.Diffs);
-                        }
-
-                        artifact.SetProperty("ResultType", compareResult.ResultType.ToString());
-
-                        artifacts.Add(artifact);
+                    if (Uri.TryCreate(compareResult.Identity, UriKind.RelativeOrAbsolute, out Uri? outUri))
+                    {
+                        artifact.Location.Uri = outUri;
                     }
 
+                    artifact.SetProperty("Analysis", compareResult.Analysis);
+
+                    if (compareResult.Base != null)
+                    {
+                        artifact.SetProperty("Base", compareResult.Base);
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(compareResult.BaseRunId))
+                    {
+                        artifact.SetProperty("BaseRunId", compareResult.BaseRunId);
+                    }
+
+                    artifact.SetProperty("ChangeType", compareResult.ChangeType);
+
+                    if (compareResult.Compare != null)
+                    {
+                        artifact.SetProperty("Compare", compareResult.Compare);
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(compareResult.CompareRunId))
+                    {
+                        artifact.SetProperty("CompareRunId", compareResult.CompareRunId);
+                    }
+
+                    if (compareResult.Diffs.Count > 0)
+                    {
+                        artifact.SetProperty("Diffs", compareResult.Diffs);
+                    }
+
+                    artifact.SetProperty("ResultType", compareResult.ResultType);
+
+                    artifacts.Add(artifact);
+                    int index = artifacts.Count - 1;
                     foreach (var rule in compareResult.Rules)
                     {
                         var sarifResult = new Result();
-                        int index = artifacts.FindIndex(a => a.Location.Description.Text == compareResult.Identity);
-
                         sarifResult.Locations = new List<Location>()
                         {
                             new Location() {
@@ -863,7 +858,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
                         }
 
                         sarifResult.Message = new Message() { Text = string.Format("{0}: {1} ({2})", rule.Name, compareResult.Identity, compareResult.ChangeType.ToString()) };
-
+                        
                         sarifResults.Add(sarifResult);
                     }
                 }

--- a/Cli/Cli.csproj
+++ b/Cli/Cli.csproj
@@ -42,8 +42,4 @@
     <PackageReference Include="Sarif.Sdk" Version="3.1.0" />
     <PackageReference Include="Tewr.Blazor.FileReader" Version="3.3.1.21360" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.5.119" />
-  </ItemGroup>
 </Project>

--- a/Lib/Lib.csproj
+++ b/Lib/Lib.csproj
@@ -58,10 +58,6 @@
     <PackageReference Include="System.Threading.AccessControl" Version="6.0.0" />
     <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="WindowsFirewallHelper" Version="2.2.0.86" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="sqlite" Version="3.13.0" />

--- a/Lib/Objects/CommandOptions.cs
+++ b/Lib/Objects/CommandOptions.cs
@@ -249,6 +249,9 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer
         [Option(HelpText = "Save to internal database for review in GUI")]
         public bool SaveToDatabase { get; set; }
 
+        [Option(HelpText = "Checks if the results of this analysis are already saved in the database. If they are will export the cached data instead of performing new analysis.")]
+        public bool ReadFromSavedComparisons { get; set; }
+        
         [Option(HelpText = "Enable running Scripts in rules")]
         public bool RunScripts { get; set; }
 

--- a/Lib/Objects/CommandOptions.cs
+++ b/Lib/Objects/CommandOptions.cs
@@ -215,6 +215,9 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer
 
         [Option(HelpText = "Second run (post-install) identifier")]
         public string SecondRunId { get; set; } = string.Empty;
+        
+        [Option(HelpText = "Checks if the results of this analysis are already saved in the database. If they are will export the cached data instead of performing new analysis.")]
+        public bool ReadFromSavedComparisons { get; set; }
     }
 
     [Verb("export-monitor", HelpText = "Output a .json report for a monitor run")]
@@ -249,9 +252,6 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer
         [Option(HelpText = "Save to internal database for review in GUI")]
         public bool SaveToDatabase { get; set; }
 
-        [Option(HelpText = "Checks if the results of this analysis are already saved in the database. If they are will export the cached data instead of performing new analysis.")]
-        public bool ReadFromSavedComparisons { get; set; }
-        
         [Option(HelpText = "Enable running Scripts in rules")]
         public bool RunScripts { get; set; }
 

--- a/Lib/Objects/CommandOptions.cs
+++ b/Lib/Objects/CommandOptions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.CST.AttackSurfaceAnalyzer.Types;
 
 namespace Microsoft.CST.AttackSurfaceAnalyzer
 {
@@ -256,6 +257,9 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer
 
         [Option(HelpText = "Force Analysis to be Single-Threaded")]
         public bool SingleThreadAnalysis { get; set; }
+
+        [Option(HelpText = "Specify the ResultLevels to report", Separator = ',')]
+        public IEnumerable<ANALYSIS_RESULT_TYPE> ResultLevels { get; set; } = new List<ANALYSIS_RESULT_TYPE>();
     }
 
     [Verb("gui", HelpText = "Launch the GUI in a browser.")]

--- a/Lib/Objects/FileSystemObject.cs
+++ b/Lib/Objects/FileSystemObject.cs
@@ -65,6 +65,8 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
         /// </summary>
         public bool? IsExecutable { get; set; }
 
+        public EXECUTABLE_TYPE ExecutableType { get; set; } = EXECUTABLE_TYPE.UNKNOWN;
+
         /// <summary>
         ///     If the file is a link
         /// </summary>

--- a/Lib/Properties/Resources.resx
+++ b/Lib/Properties/Resources.resx
@@ -126,6 +126,9 @@
   <data name="Comparing" xml:space="preserve">
     <value>Comparing {0} vs {1}.</value>
   </data>
+  <data name="LoadingSavedComparison" xml:space="preserve">
+    <value>Loading saved comparison of {0} vs {1} with Analysis Hash {2}.</value>
+  </data>
   <data name="DeletedDatabase" xml:space="preserve">
     <value>Successfully deleted database.</value>
   </data>

--- a/analyses.json
+++ b/analyses.json
@@ -48,7 +48,7 @@
         "MODIFIED"
       ],
       "ResultType": "FILE",
-      "Expression": "is_exe AND ((windows_exe AND NOT valid_windows_signature) OR (mac_binary AND null_mac_signature))",
+      "Expression": "(is_exe AND windows_exe AND NOT valid_windows_signature) OR (is_exe AND mac_binary AND null_mac_signature)",
       "Clauses": [
         {
           "Label": "is_exe",
@@ -88,7 +88,7 @@
         "MODIFIED"
       ],
       "ResultType": "FILEMONITOR",
-      "Expression": "is_exe AND ((windows_exe AND NOT valid_windows_signature) OR (mac_binary AND null_mac_signature))",
+      "Expression": "(is_exe AND windows_exe AND NOT valid_windows_signature) OR (is_exe AND mac_binary AND null_mac_signature)",
       "Clauses": [
         {
           "Label": "is_exe",

--- a/analyses.json
+++ b/analyses.json
@@ -48,7 +48,7 @@
         "MODIFIED"
       ],
       "ResultType": "FILE",
-      "Expression": "is_exe AND NOT valid_windows_signature AND null_mac_signature",
+      "Expression": "is_exe AND ((windows_exe AND NOT valid_windows_signature) OR (mac_binary AND null_mac_signature))",
       "Clauses": [
         {
           "Label": "is_exe",
@@ -56,9 +56,21 @@
           "Operation": "IsTrue"
         },
         {
+          "Label": "windows_exe",
+          "Field": "ExecutableType",
+          "Operation": "Equals",
+          "Data": ["WINDOWS"]
+        },
+        {
           "Label": "valid_windows_signature",
           "Field": "SignatureStatus.IsAuthenticodeValid",
           "Operation": "IsTrue"
+        },
+        {
+          "Label": "mac_binary",
+          "Field": "ExecutableType",
+          "Operation": "Equals",
+          "Data": ["MACOS"]
         },
         {
           "Label": "null_mac_signature",
@@ -76,7 +88,7 @@
         "MODIFIED"
       ],
       "ResultType": "FILEMONITOR",
-      "Expression": "is_exe AND NOT valid_windows_signature AND null_mac_signature",
+      "Expression": "is_exe AND ((windows_exe AND NOT valid_windows_signature) OR (mac_binary AND null_mac_signature))",
       "Clauses": [
         {
           "Label": "is_exe",
@@ -84,9 +96,21 @@
           "Operation": "IsTrue"
         },
         {
+          "Label": "windows_exe",
+          "Field": "FileSystemObject.ExecutableType",
+          "Operation": "Equals",
+          "Data": ["WINDOWS"]
+        },
+        {
           "Label": "valid_windows_signature",
           "Field": "FileSystemObject.SignatureStatus.IsAuthenticodeValid",
           "Operation": "IsTrue"
+        },
+        {
+          "Label": "mac_binary",
+          "Field": "FileSystemObject.ExecutableType",
+          "Operation": "Equals",
+          "Data": ["MACOS"]
         },
         {
           "Label": "null_mac_signature",


### PR DESCRIPTION
* Fixes reporting linux binaries are unsigned by adding new field to FileSystemObject for executable type. Rule is now restricted to Windows and Mac executable types. (Signature checking for linux binaries is not implemented in ASA). 
* Adds ability to filter results from Export Collect by Analysis Result Type (i.e. WARNING, ERROR etc). Specify using comma separated list of the levels you want to be exported.
* Adds option to export collect results which were saved to the database instead of redoing comparison. Note, to #667 this is unlikely to be faster than just doing the normal export.
* Fixes output sarif performance.