### PR TITLE
Fix RegistryWalker

### DIFF
--- a/Lib/Utils/RegistryWalker.cs
+++ b/Lib/Utils/RegistryWalker.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Utils
                         {
                             foreach (string subkey in currentKey.GetSubKeyNames())
                             {
-                                keys.Push($"{key}\\{subkey}");
+                                keys.Push(!string.IsNullOrEmpty(key) ? $"{key}\\{subkey}" : subkey);
                             }
                         }
                     }


### PR DESCRIPTION
Walker was improperly appending `\` to the key in the registry collector when the subkey was the first portion of the path in the hive, preventing deeper walking.

Fix #700 