### PR TITLE
Fix Sarif output of results with no rule match

### DIFF
--- a/Cli/AttackSurfaceAnalyzerClient.cs
+++ b/Cli/AttackSurfaceAnalyzerClient.cs
@@ -899,7 +899,37 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
 
                     artifacts.Add(artifact);
                     int index = artifacts.Count - 1;
-                    foreach (var rule in compareResult.Rules)
+                    if (compareResult.Rules.Any())
+                    {
+                        foreach (var rule in compareResult.Rules)
+                        {
+                            var sarifResult = new Result();
+                            sarifResult.Locations = new List<Location>()
+                            {
+                                new Location() {
+                                    PhysicalLocation = new PhysicalLocation()
+                                    {
+                                        ArtifactLocation = new ArtifactLocation()
+                                        {
+                                            Index = index
+                                        }
+                                    }
+                                }
+                            };
+
+                            sarifResult.Level = GetSarifFailureLevel((ANALYSIS_RESULT_TYPE)rule.Severity);
+
+                            if (!string.IsNullOrWhiteSpace(rule.Name))
+                            {
+                                sarifResult.RuleId = rule.Name;
+                            }
+
+                            sarifResult.Message = new Message() { Text = string.Format("{0}: {1} ({2})", rule.Name, compareResult.Identity, compareResult.ChangeType) };
+                        
+                            sarifResults.Add(sarifResult);
+                        }
+                    }
+                    else
                     {
                         var sarifResult = new Result();
                         sarifResult.Locations = new List<Location>()
@@ -915,14 +945,11 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
                             }
                         };
 
-                        sarifResult.Level = GetSarifFailureLevel((ANALYSIS_RESULT_TYPE)rule.Severity);
+                        sarifResult.Level = GetSarifFailureLevel(compareResult.Analysis);
 
-                        if (!string.IsNullOrWhiteSpace(rule.Name))
-                        {
-                            sarifResult.RuleId = rule.Name;
-                        }
+                        sarifResult.RuleId = "Default Level";
 
-                        sarifResult.Message = new Message() { Text = string.Format("{0}: {1} ({2})", rule.Name, compareResult.Identity, compareResult.ChangeType) };
+                        sarifResult.Message = new Message() { Text = string.Format("Default Level: {0} ({1})", compareResult.Identity, compareResult.ChangeType) };
                         
                         sarifResults.Add(sarifResult);
                     }

--- a/Cli/AttackSurfaceAnalyzerClient.cs
+++ b/Cli/AttackSurfaceAnalyzerClient.cs
@@ -715,6 +715,15 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
         internal static ASA_ERROR ExportCompareResults(ConcurrentDictionary<(RESULT_TYPE, CHANGE_TYPE), ConcurrentBag<CompareResult>> resultsIn, ExportOptions opts, string baseFileName, string analysesHash, IEnumerable<AsaRule> rules)
         {
             var results = resultsIn.Select(x => new KeyValuePair<string, object>($"{x.Key.Item1}_{x.Key.Item2}", x.Value)).ToDictionary(x => x.Key, x => x.Value);
+            if (opts.DisableImplicitFindings) 
+            {
+                var resultKeys = resultsIn.Keys;
+                foreach (var key in resultKeys)
+                {
+                    var newBag = new ConcurrentBag<CompareResult>(resultsIn[key].Where(x => !x.Rules.Any()));
+                    resultsIn[key] = newBag;
+                }
+            }
             JsonSerializer serializer = JsonSerializer.Create(new JsonSerializerSettings()
             {
                 Formatting = Formatting.Indented,
@@ -741,7 +750,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
                     string filePath = Path.Combine(path, AsaHelpers.MakeValidFileName(key));
                     if (opts.OutputSarif)
                     {
-                        WriteSarifLog(new Dictionary<string, object>() { { key, results[key] } }, rules, filePath);
+                        WriteSarifLog(new Dictionary<string, object>() { { key, results[key] } }, rules, filePath, opts.DisableImplicitFindings);
                     }
                     else
                     {
@@ -762,12 +771,11 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
                 if (opts.OutputSarif)
                 {
                     string pathSarif = Path.Combine(outputPath, AsaHelpers.MakeValidFileName(baseFileName + "_summary.Sarif"));
-                    WriteSarifLog(output, rules, pathSarif);
+                    WriteSarifLog(output, rules, pathSarif, opts.DisableImplicitFindings);
                     Log.Information(Strings.Get("OutputWrittenTo"), (new FileInfo(pathSarif)).FullName);
                 }
                 else
                 {
-
                     using (StreamWriter sw = new(path)) //lgtm[cs/path-injection]
                     {
                         using JsonWriter writer = new JsonTextWriter(sw);
@@ -785,9 +793,10 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
         /// <param name="output">output of the analyzer result</param>
         /// <param name="rules">list of rules used</param>
         /// <param name="outputFilePath">file path of the Sarif log</param>
-        public static void WriteSarifLog(Dictionary<string, object> output, IEnumerable<AsaRule> rules, string outputFilePath)
+        /// <param name="disableImplicitFindings">If the output should exclude results with no explicit level</param>
+        internal static void WriteSarifLog(Dictionary<string, object> output, IEnumerable<AsaRule> rules, string outputFilePath, bool disableImplicitFindings)
         {
-            var log = GenerateSarifLog(output, rules);
+            var log = GenerateSarifLog(output, rules, disableImplicitFindings);
 
             var settings = new JsonSerializerSettings()
             {
@@ -797,7 +806,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
             File.WriteAllText(outputFilePath, JsonConvert.SerializeObject(log, settings));
         }
 
-        public static SarifLog GenerateSarifLog(Dictionary<string, object> output, IEnumerable<AsaRule> rules)
+        public static SarifLog GenerateSarifLog(Dictionary<string, object> output, IEnumerable<AsaRule> rules, bool disableImplicitFindings)
         {
             var metadata = (Dictionary<string, string>)output["metadata"];
             var results = (Dictionary<string, object>)output["results"];
@@ -931,27 +940,30 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Cli
                     }
                     else
                     {
-                        var sarifResult = new Result();
-                        sarifResult.Locations = new List<Location>()
+                        if (!disableImplicitFindings)
                         {
-                            new Location() {
-                                PhysicalLocation = new PhysicalLocation()
-                                {
-                                    ArtifactLocation = new ArtifactLocation()
+                            var sarifResult = new Result();
+                            sarifResult.Locations = new List<Location>()
+                            {
+                                new Location() {
+                                    PhysicalLocation = new PhysicalLocation()
                                     {
-                                        Index = index
+                                        ArtifactLocation = new ArtifactLocation()
+                                        {
+                                            Index = index
+                                        }
                                     }
                                 }
-                            }
-                        };
+                            };
 
-                        sarifResult.Level = GetSarifFailureLevel(compareResult.Analysis);
+                            sarifResult.Level = GetSarifFailureLevel(compareResult.Analysis);
 
-                        sarifResult.RuleId = "Default Level";
+                            sarifResult.RuleId = "Default Level";
 
-                        sarifResult.Message = new Message() { Text = string.Format("Default Level: {0} ({1})", compareResult.Identity, compareResult.ChangeType) };
+                            sarifResult.Message = new Message() { Text = string.Format("Default Level: {0} ({1})", compareResult.Identity, compareResult.ChangeType) };
                         
-                        sarifResults.Add(sarifResult);
+                            sarifResults.Add(sarifResult);
+                        }
                     }
                 }
             }

--- a/Lib/Objects/CommandOptions.cs
+++ b/Lib/Objects/CommandOptions.cs
@@ -258,6 +258,10 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer
         [Option(HelpText = "Output Sarif")]
         public bool OutputSarif { get; set; }
 
+        // Don't output results if they do not have an explicit rule applied
+        [Option(HelpText = "Ignore results with no explicit rule match")]
+        public bool DisableImplicitFindings { get; set; }
+
         [Option(HelpText = "Force Analysis to be Single-Threaded")]
         public bool SingleThreadAnalysis { get; set; }
 

--- a/Tests/ExportTests.cs
+++ b/Tests/ExportTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Tests
             var outputDictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(outputJson, jsonSettings);
             var rulesList = JsonConvert.DeserializeObject<IEnumerable<AsaRule>>(rulesJson, jsonSettings);
 
-            var sarif = AttackSurfaceAnalyzerClient.GenerateSarifLog(outputDictionary, rulesList);
+            var sarif = AttackSurfaceAnalyzerClient.GenerateSarifLog(outputDictionary, rulesList, false);
 
             Assert.AreEqual(sarif.Runs[0].Artifacts.Count, 3);
             Assert.IsTrue(sarif.Runs[0].Artifacts.Any(a => a.Location.Description.Text == "C:\\Test\\Scan2\\TestAddText.txt"));

--- a/Tests/ExportTests.cs
+++ b/Tests/ExportTests.cs
@@ -40,18 +40,32 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Tests
             var outputDictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(outputJson, jsonSettings);
             var rulesList = JsonConvert.DeserializeObject<IEnumerable<AsaRule>>(rulesJson, jsonSettings);
 
-            var sarif = AttackSurfaceAnalyzerClient.GenerateSarifLog(outputDictionary, rulesList, false);
+            var sarif = AttackSurfaceAnalyzerClient.GenerateSarifLog(outputDictionary, rulesList, true);
 
-            Assert.AreEqual(sarif.Runs[0].Artifacts.Count, 3);
+            Assert.AreEqual(3, sarif.Runs[0].Artifacts.Count);
             Assert.IsTrue(sarif.Runs[0].Artifacts.Any(a => a.Location.Description.Text == "C:\\Test\\Scan2\\TestAddText.txt"));
             Assert.IsTrue(sarif.Runs[0].Artifacts.Any(a => a.Location.Description.Text == "C:\\Test\\Scan2\\TestAddExe.exe"));
             Assert.IsTrue(sarif.Runs[0].Artifacts.Any(a => a.Location.Description.Text == "C:\\Test\\Scan2\\TestModifyExe.exe"));
-            Assert.AreEqual(sarif.Runs[0].Results.Count, 6);
+            Assert.AreEqual(6, sarif.Runs[0].Results.Count);
             Assert.IsTrue(sarif.Runs[0].Results.Any(r => r.Message.Text == "Missing DEP: C:\\Test\\Scan2\\TestAddExe.exe (CREATED)"));
             Assert.IsTrue(sarif.Runs[0].Results.Any(r => r.Message.Text == "Missing ASLR: C:\\Test\\Scan2\\TestAddExe.exe (CREATED)"));
             Assert.IsTrue(sarif.Runs[0].Results.Any(r => r.Message.Text == "Unsigned binaries: C:\\Test\\Scan2\\TestAddExe.exe (CREATED)"));
             Assert.IsFalse(sarif.Runs[0].Results.Any(r => r.Message.Text.Contains("TestAddText.txt")));
-            Assert.AreEqual(sarif.Runs[0].Tool.Driver.Rules.Count, 41);
+            Assert.AreEqual(41, sarif.Runs[0].Tool.Driver.Rules.Count);
+            Assert.IsTrue(sarif.Runs[0].Tool.Driver.Rules.Any(r => r.FullDescription.Text == "Flag when privileged ports are opened."));
+
+            // Test with allowing impliciting findings
+            sarif = AttackSurfaceAnalyzerClient.GenerateSarifLog(outputDictionary, rulesList, false);
+            Assert.AreEqual(3, sarif.Runs[0].Artifacts.Count);
+            Assert.IsTrue(sarif.Runs[0].Artifacts.Any(a => a.Location.Description.Text == "C:\\Test\\Scan2\\TestAddText.txt"));
+            Assert.IsTrue(sarif.Runs[0].Artifacts.Any(a => a.Location.Description.Text == "C:\\Test\\Scan2\\TestAddExe.exe"));
+            Assert.IsTrue(sarif.Runs[0].Artifacts.Any(a => a.Location.Description.Text == "C:\\Test\\Scan2\\TestModifyExe.exe"));
+            Assert.AreEqual(7, sarif.Runs[0].Results.Count);
+            Assert.IsTrue(sarif.Runs[0].Results.Any(r => r.Message.Text == "Missing DEP: C:\\Test\\Scan2\\TestAddExe.exe (CREATED)"));
+            Assert.IsTrue(sarif.Runs[0].Results.Any(r => r.Message.Text == "Missing ASLR: C:\\Test\\Scan2\\TestAddExe.exe (CREATED)"));
+            Assert.IsTrue(sarif.Runs[0].Results.Any(r => r.Message.Text == "Unsigned binaries: C:\\Test\\Scan2\\TestAddExe.exe (CREATED)"));
+            Assert.IsTrue(sarif.Runs[0].Results.Any(r => r.Message.Text.Contains("TestAddText.txt")));
+            Assert.AreEqual(41, sarif.Runs[0].Tool.Driver.Rules.Count);
             Assert.IsTrue(sarif.Runs[0].Tool.Driver.Rules.Any(r => r.FullDescription.Text == "Flag when privileged ports are opened."));
         }
     }


### PR DESCRIPTION
The JSON report was outputting results with no explicit rule match and only default level but the sarif results were not. This ensures those results appear in the sarif report and adds new `DisableImplicitFindings` argument to export-collect to ignore such findings consistent with old behavior, and now consistent in json and sarif output formats.