### PR TITLE
Use MSTest SDK

### DIFF
--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,8 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSTest.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
-    <IsPackable>false</IsPackable>
     <AssemblyName>AsaTests</AssemblyName>
     <ReleaseVersion>2.1-alpha</ReleaseVersion>
   </PropertyGroup>
@@ -10,12 +9,6 @@
   <ItemGroup>
     <Content Include="..\LICENSE.txt" Link="LICENSE.txt" />
     <Content Include="..\NOTICE.txt" Link="NOTICE.txt" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "msbuild-sdks": {
+    "MSTest.Sdk": "3.5.2"
+  }
+}


### PR DESCRIPTION
Update the test project to use `MSTest SDK` ([documentation](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-sdk) and [blogpost](https://devblogs.microsoft.com/dotnet/introducing-mstest-sdk/)).

Updates to latest version (from 2.2.5 to 3.5.2).

This is also enabling the use of MSTest runner ([documentation](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-runner-intro) and [blogpost](https://devblogs.microsoft.com/dotnet/introducing-ms-test-runner/)).