### PR TITLE
Use MSTest 3.7.1 + new test runner

### DIFF
--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -5,6 +5,10 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>AsaTests</AssemblyName>
     <ReleaseVersion>2.1-alpha</ReleaseVersion>
+	<EnableMSTestRunner>true</EnableMSTestRunner>
+	<OutputType>Exe</OutputType>
+	<TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+	<TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,9 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
+    <PackageReference Include="MSTest" Version="3.7.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi,

I am Amaury from .NET testing team and I see that you are relying on unsupported and old version of MSTest. This PR is bumping to newer version and using the new testing platform (replacement of VSTest).

I sadly cannot have green test run locally (4 tests failing before any change) but I see that for the single test project you have, we have about 4s faster test run.

Happy to give you more details or have a call if you are interested to know more.