### PR TITLE
Restrict Tests run in Pipeline

### DIFF
--- a/Pipelines/asa-pr.yml
+++ b/Pipelines/asa-pr.yml
@@ -22,7 +22,7 @@ resources:
     - repository: templates
       type: git
       name: SecurityEngineering/OSS-Tools-Pipeline-Templates
-      ref: refs/tags/v2.0.0
+      ref: refs/tags/v2.0.1
     - repository: 1esPipelines
       type: git
       name: 1ESPipelineTemplates/1ESPipelineTemplates
@@ -52,6 +52,7 @@ extends:
           poolImage: MSSecurity-1ES-Windows-2022
           poolOs: windows
           projectPath: 'Tests/Tests.csproj'
+          dotnetTestArgs: '--filter TestCategory=PipelineSafeTests'
 
     - stage: Build
       dependsOn: Test

--- a/Pipelines/asa-release.yml
+++ b/Pipelines/asa-release.yml
@@ -7,7 +7,7 @@ resources:
     - repository: templates
       type: git
       name: Data/OSS-Tools-Pipeline-Templates
-      ref: refs/tags/v2.0.0
+      ref: refs/tags/v2.0.1
     - repository: 1esPipelines
       type: git
       name: 1ESPipelineTemplates/1ESPipelineTemplates
@@ -42,6 +42,8 @@ extends:
           poolImage: MSSecurity-1ES-Windows-2022
           poolOs: windows
           projectPath: 'Tests/Tests.csproj'
+          dotnetTestArgs: '--filter TestCategory=PipelineSafeTests'
+
     - stage: Build
       dependsOn: Test
       jobs:

--- a/Tests/AsaAnalyzerTests.cs
+++ b/Tests/AsaAnalyzerTests.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace Microsoft.CST.AttackSurfaceAnalyzer.Tests
 {
-    [TestClass]
+    [TestClass, TestCategory("PipelineSafeTests")]
     public class AsaAnalyzerTests
     {
         public AsaAnalyzerTests()

--- a/Tests/CollectorTests.cs
+++ b/Tests/CollectorTests.cs
@@ -429,7 +429,6 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Tests
         /// <summary>
         ///     Requires Admin
         /// </summary>
-        [Ignore]
         [TestMethod]
         public void TestTpmCollector()
         {

--- a/Tests/DiffTests.cs
+++ b/Tests/DiffTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Tests;
 /// <summary>
 /// Test that the compare logic generates the correct diffs for various object configurations
 /// </summary>
-[TestClass]
+[TestClass, TestCategory("PipelineSafeTests")]
 public class DiffTests
 {
     [DataRow("owner1", "owner2", 1)]

--- a/Tests/ExportTests.cs
+++ b/Tests/ExportTests.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace Microsoft.CST.AttackSurfaceAnalyzer.Tests
 {
-    [TestClass]
+    [TestClass, TestCategory("PipelineSafeTests")]
     public class ExportTests
     {
         [ClassInitialize]

--- a/Tests/HydrationTests.cs
+++ b/Tests/HydrationTests.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 
 namespace Microsoft.CST.AttackSurfaceAnalyzer.Tests
 {
-    [TestClass]
+    [TestClass, TestCategory("PipelineSafeTests")]
     public class HydrationTests
     {
         [ClassInitialize]

--- a/Tests/InMemoryComparatorTests.cs
+++ b/Tests/InMemoryComparatorTests.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace Microsoft.CST.AttackSurfaceAnalyzer.Tests
 {
-    [TestClass]
+    [TestClass, TestCategory("PipelineSafeTests")]
     public class InMemoryComparatorTests
     {
         [ClassInitialize]

--- a/Tests/RuleFileTests.cs
+++ b/Tests/RuleFileTests.cs
@@ -21,7 +21,7 @@ using WindowsFirewallHelper;
 
 namespace Microsoft.CST.AttackSurfaceAnalyzer.Tests
 {
-    [TestClass]
+    [TestClass, TestCategory("PipelineSafeTests")]
     public class RuleFileTests
     {
         [ClassInitialize]

--- a/Tests/RuleFileTests.cs
+++ b/Tests/RuleFileTests.cs
@@ -1,23 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License.
-using Microsoft.CST.AttackSurfaceAnalyzer.Collectors;
 using Microsoft.CST.AttackSurfaceAnalyzer.Objects;
 using Microsoft.CST.AttackSurfaceAnalyzer.Types;
 using Microsoft.CST.AttackSurfaceAnalyzer.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.Win32;
-using Serilog;
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Net;
-using System.Net.Sockets;
-using System.Runtime.InteropServices;
-using System.Threading;
-using Tpm2Lib;
-using WindowsFirewallHelper;
 
 namespace Microsoft.CST.AttackSurfaceAnalyzer.Tests
 {


### PR DESCRIPTION
Adds a `PipelineSafeTest` category and restricts pipeline to execute subset of tests excluding collector tests.