### PR TITLE
Update NuGet package versions across projects

### DIFF
--- a/Benchmarks/Benchmarks.csproj
+++ b/Benchmarks/Benchmarks.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.119" />
+    <PackageReference Include="System.Data.SQLite" Version="2.0.1" />
     <PackageReference Include="murmurhash" Version="1.0.3" />
   </ItemGroup>
 

--- a/Cli/Cli.csproj
+++ b/Cli/Cli.csproj
@@ -37,8 +37,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.2.79" />
-    <PackageReference Include="Microsoft.CST.OAT.Scripting" Version="1.2.79" />
+    <PackageReference Include="Microsoft.CST.OAT.Blazor.Components" Version="1.2.87" />
+    <PackageReference Include="Microsoft.CST.OAT.Scripting" Version="1.2.87" />
     <PackageReference Include="Sarif.Sdk" Version="4.5.4" />
     <PackageReference Include="Tewr.Blazor.FileReader" Version="3.4.0.24340" />
   </ItemGroup>

--- a/Lib/Lib.csproj
+++ b/Lib/Lib.csproj
@@ -37,24 +37,24 @@
     <PackageReference Include="MedallionShell" Version="1.6.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageReference Include="Microsoft.CST.OAT" Version="1.2.79" />
-    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.41" />
+    <PackageReference Include="Microsoft.CST.OAT" Version="1.2.87" />
+    <PackageReference Include="Microsoft.CST.RecursiveExtractor" Version="1.2.45" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.9" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="9.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="System.Management" Version="9.0.7" />
+    <PackageReference Include="System.Management" Version="9.0.9" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="9.0.9" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
-    <PackageReference Include="System.Threading.AccessControl" Version="9.0.7" />
+    <PackageReference Include="System.Threading.AccessControl" Version="9.0.9" />
     <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="WindowsFirewallHelper" Version="2.2.0.86" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -14,8 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.10.4" />
     <PackageReference Update="MSTest.Analyzers" Version="3.7.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Upgraded various NuGet dependencies in Benchmarks, Cli, Lib, and Tests projects to their latest versions. This includes updates to System.Data.SQLite, Microsoft.CST.OAT, Microsoft.CST.RecursiveExtractor, Microsoft.Data.Sqlite, Microsoft.Windows.Compatibility, MSTest, and others to ensure compatibility, security, and access to new features.