### PR TITLE
Update pipeline template reference to v2.0.4

### DIFF
--- a/Pipelines/asa-release.yml
+++ b/Pipelines/asa-release.yml
@@ -7,7 +7,7 @@ resources:
     - repository: templates
       type: git
       name: Data/OSS-Tools-Pipeline-Templates
-      ref: refs/tags/v2.0.1
+      ref: refs/tags/v2.0.4
     - repository: 1esPipelines
       type: git
       name: 1ESPipelineTemplates/1ESPipelineTemplates


### PR DESCRIPTION
Bumped the Data/OSS-Tools-Pipeline-Templates repository reference from v2.0.1 to v2.0.4 in asa-release.yml to use the latest pipeline templates.