### PR TITLE
Add release NuGet config and update pipeline references

### DIFF
--- a/NuGet.Config.AzureArtifacts.Release
+++ b/NuGet.Config.AzureArtifacts.Release
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="Data_PublicPackages" value="https://pkgs.dev.azure.com/twcdot/Data/_packaging/Data_PublicPackages/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/Pipelines/asa-release.yml
+++ b/Pipelines/asa-release.yml
@@ -45,7 +45,7 @@ extends:
           dotnetTestArgs: '--filter TestCategory=PipelineSafeTests'
           includeNuGetOrg: false
           nugetFeedsToUse: 'config'
-          nugetConfigPath: 'NuGet.Config.AzureArtifacts'
+          nugetConfigPath: 'NuGet.Config.AzureArtifacts.Release'
           onInit:
             - task: NuGetAuthenticate@1
 
@@ -63,7 +63,7 @@ extends:
           artifactName: 'linux-mac-archive'
           includeNuGetOrg: false
           nugetFeedsToUse: 'config'
-          nugetConfigPath: 'NuGet.Config.AzureArtifacts'
+          nugetConfigPath: 'NuGet.Config.AzureArtifacts.Release'
           onInit:
             - task: NuGetAuthenticate@1
           preBuild:
@@ -78,7 +78,7 @@ extends:
           artifactName: 'cli-archive'
           includeNuGetOrg: false
           nugetFeedsToUse: 'config'
-          nugetConfigPath: 'NuGet.Config.AzureArtifacts'
+          nugetConfigPath: 'NuGet.Config.AzureArtifacts.Release'
           onInit:
             - task: NuGetAuthenticate@1
           preBuild:
@@ -93,7 +93,7 @@ extends:
           artifactName: 'nuget-lib-archive'
           includeNuGetOrg: false
           nugetFeedsToUse: 'config'
-          nugetConfigPath: 'NuGet.Config.AzureArtifacts'
+          nugetConfigPath: 'NuGet.Config.AzureArtifacts.Release'
           onInit:
             - task: NuGetAuthenticate@1
           preBuild:
@@ -108,7 +108,7 @@ extends:
           artifactName: 'nuget-cli-archive'
           includeNuGetOrg: false
           nugetFeedsToUse: 'config'
-          nugetConfigPath: 'NuGet.Config.AzureArtifacts'
+          nugetConfigPath: 'NuGet.Config.AzureArtifacts.Release'
           onInit:
             - task: NuGetAuthenticate@1
           preBuild:


### PR DESCRIPTION
Introduced NuGet.Config.AzureArtifacts.Release for release builds and updated asa-release.yml to reference the new config file in all relevant steps. This ensures the pipeline uses the correct package source configuration for release scenarios.