### PR TITLE
Fix Authenticode signing time extraction and split signature validity rules

### DIFF
--- a/Lib/Collectors/WindowsFileSystemUtils.cs
+++ b/Lib/Collectors/WindowsFileSystemUtils.cs
@@ -8,6 +8,7 @@ using PeNet.Header.Pe;
 using Serilog;
 using System;
 using System.Collections.Generic;
+using System.Formats.Asn1;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
@@ -202,10 +203,26 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
         }
 
         /// <summary>
+        /// Microsoft's Authenticode RFC 3161 timestamp unsigned attribute (szOID_RFC3161_counterSign).
+        /// This is what modern Windows binaries are timestamped with.
+        /// </summary>
+        private const string MicrosoftRfc3161TimestampOid = "1.3.6.1.4.1.311.3.3.1";
+
+        /// <summary>
+        /// The standard RFC 3161 signature timestamp unsigned attribute (id-aa-signatureTimeStampToken).
+        /// </summary>
+        private const string Rfc3161TimestampOid = "1.2.840.113549.1.9.16.2.14";
+
+        /// <summary>
+        /// The content type of the TSTInfo encapsulated in an RFC 3161 timestamp token (id-ct-TSTInfo).
+        /// </summary>
+        private const string TstInfoContentTypeOid = "1.2.840.113549.1.9.16.1.4";
+
+        /// <summary>
         /// Extracts the signing timestamp from a PE file's Authenticode signature.
-        /// The method first attempts to use the countersigner info in the PKCS#7 data,
-        /// then checks for RFC3161 timestamp tokens in the signer's UnsignedAttributes,
-        /// and finally falls back to the signer's own SignedAttributes if needed.
+        /// The method first attempts to use the countersigner info in the PKCS#7 data (the legacy
+        /// Authenticode timestamp format), then checks for RFC 3161 timestamp tokens in the signer's
+        /// UnsignedAttributes, and finally falls back to the signer's own SignedAttributes if needed.
         /// </summary>
         internal static DateTime? GetSigningTime(PeFile peFile)
         {
@@ -222,7 +239,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
 
                 foreach (var signerInfo in signedCms.SignerInfos)
                 {
-                    // Check counter-signers for the Authenticode timestamp
+                    // Legacy Authenticode timestamps are PKCS#9 countersignatures carrying a signingTime attribute
                     foreach (var counterSigner in signerInfo.CounterSignerInfos)
                     {
                         var time = GetPkcs9SigningTime(counterSigner.SignedAttributes);
@@ -230,34 +247,25 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
                             return time;
                     }
 
-                    // Check unsigned attributes for RFC 3161 timestamp tokens
+                    // Modern Authenticode timestamps are RFC 3161 tokens carried in an unsigned attribute
                     foreach (var attr in signerInfo.UnsignedAttributes)
                     {
-                        // RFC 3161 timestamp token OID: 1.2.840.113549.1.9.16.2.14 (signatureTimeStampToken)
-                        if (string.Equals(attr.Oid?.Value, "1.2.840.113549.1.9.16.2.14", StringComparison.Ordinal))
+                        if (!string.Equals(attr.Oid?.Value, MicrosoftRfc3161TimestampOid, StringComparison.Ordinal) &&
+                            !string.Equals(attr.Oid?.Value, Rfc3161TimestampOid, StringComparison.Ordinal))
                         {
-                            foreach (var val in attr.Values)
-                            {
-                                try
-                                {
-                                    var tokenCms = new SignedCms();
-                                    tokenCms.Decode(val.RawData);
-                                    foreach (var tokenSigner in tokenCms.SignerInfos)
-                                    {
-                                        var time = GetPkcs9SigningTime(tokenSigner.SignedAttributes);
-                                        if (time.HasValue)
-                                            return time;
-                                    }
-                                }
-                                catch (CryptographicException)
-                                {
-                                    // Not a valid CMS structure, skip
-                                }
-                            }
+                            continue;
+                        }
+
+                        foreach (var val in attr.Values)
+                        {
+                            var time = GetRfc3161TimestampTime(val.RawData);
+                            if (time.HasValue)
+                                return time;
                         }
                     }
 
-                    // Fallback: check the signer's own signed attributes
+                    // Fallback: check the signer's own signed attributes. This time is asserted by the
+                    // signer rather than by a trusted timestamp authority.
                     var signerTime = GetPkcs9SigningTime(signerInfo.SignedAttributes);
                     if (signerTime.HasValue)
                         return signerTime;
@@ -268,6 +276,63 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Collectors
                 Log.Verbose(e, "Failed to extract signing time ({0}:{1})", e.GetType(), e.Message);
             }
             return null;
+        }
+
+        /// <summary>
+        /// Extracts the trusted time from an RFC 3161 timestamp token. The authoritative value is the
+        /// genTime of the encapsulated TSTInfo; timestamp authorities are not required to also place a
+        /// PKCS#9 signingTime attribute on the token's signer, so that is only used as a fallback.
+        /// </summary>
+        private static DateTime? GetRfc3161TimestampTime(byte[] tokenData)
+        {
+            try
+            {
+                var tokenCms = new SignedCms();
+                tokenCms.Decode(tokenData);
+
+                if (string.Equals(tokenCms.ContentInfo.ContentType?.Value, TstInfoContentTypeOid, StringComparison.Ordinal))
+                {
+                    var genTime = GetTstInfoGenTime(tokenCms.ContentInfo.Content);
+                    if (genTime.HasValue)
+                        return genTime;
+                }
+
+                foreach (var tokenSigner in tokenCms.SignerInfos)
+                {
+                    var time = GetPkcs9SigningTime(tokenSigner.SignedAttributes);
+                    if (time.HasValue)
+                        return time;
+                }
+            }
+            catch (CryptographicException)
+            {
+                // Not a valid CMS structure, skip
+            }
+            catch (AsnContentException)
+            {
+                // Malformed ASN.1, skip
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Reads the genTime field out of a DER encoded RFC 3161 TSTInfo structure.
+        /// </summary>
+        private static DateTime? GetTstInfoGenTime(byte[] tstInfo)
+        {
+            try
+            {
+                var reader = new AsnReader(tstInfo, AsnEncodingRules.BER).ReadSequence();
+                reader.ReadInteger();          // version
+                reader.ReadObjectIdentifier(); // policy
+                reader.ReadSequence();         // messageImprint
+                reader.ReadInteger();          // serialNumber
+                return reader.ReadGeneralizedTime().UtcDateTime;
+            }
+            catch (AsnContentException)
+            {
+                return null;
+            }
         }
 
         private static DateTime? GetPkcs9SigningTime(CryptographicAttributeObjectCollection attributes)

--- a/Lib/Objects/Signature.cs
+++ b/Lib/Objects/Signature.cs
@@ -38,13 +38,24 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
         {
         }
 
+        /// <summary>
+        ///     True when the signature carries a signing time which falls inside the signing
+        ///     certificate's validity period. A binary that was correctly signed and timestamped stays
+        ///     valid here even after its certificate expires. False when the signing time could not be
+        ///     determined, so callers that need to distinguish "signed outside validity" from "signing
+        ///     time unknown" should also inspect <see cref="SigningTime"/>.
+        /// </summary>
         public bool IsTimeValid
         {
             get
             {
-                if (SigningCertificate != null && SigningTime is DateTime signingTime)
+                if (SigningCertificate is SerializableCertificate certificate && SigningTime is DateTime signingTime)
                 {
-                    return signingTime >= SigningCertificate.NotBefore && signingTime <= SigningCertificate.NotAfter;
+                    // Signing times are recovered as UTC while certificate validity comes back from
+                    // X509Certificate2 as local time, so both sides are normalized before comparing.
+                    var signedAtUtc = signingTime.ToUniversalTime();
+                    return signedAtUtc >= certificate.NotBefore.ToUniversalTime() &&
+                           signedAtUtc <= certificate.NotAfter.ToUniversalTime();
                 }
                 return false;
             }
@@ -54,6 +65,11 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Objects
         public string? SignedHash { get; set; }
         public string? SignerSerialNumber { get; set; }
         public SerializableCertificate? SigningCertificate { get; set; }
+
+        /// <summary>
+        ///     The time the binary was signed, recovered from the Authenticode timestamp when one is
+        ///     present. Null when the signature is absent or carries no recoverable timestamp.
+        /// </summary>
         public DateTime? SigningTime { get; set; }
     }
 }

--- a/Tests/SignatureTests.cs
+++ b/Tests/SignatureTests.cs
@@ -1,83 +1,96 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License.
 using Microsoft.CST.AttackSurfaceAnalyzer.Collectors;
 using Microsoft.CST.AttackSurfaceAnalyzer.Objects;
+using Microsoft.CST.AttackSurfaceAnalyzer.Types;
+using Microsoft.CST.AttackSurfaceAnalyzer.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PeNet;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Security.Cryptography.Pkcs;
 
 namespace Microsoft.CST.AttackSurfaceAnalyzer.Tests
 {
     [TestClass, TestCategory("PipelineSafeTests")]
     public class SignatureTests
     {
+        private const string OutsideValidityRule = "Binaries signed outside certificate validity period";
+        private const string UndeterminableTimeRule = "Binaries with an undeterminable signing time";
+
+        /// <summary>
+        ///     A binary timestamped with the legacy Authenticode format, where the signing time lives in a
+        ///     PKCS#9 countersignature.
+        /// </summary>
+        private static readonly string LegacyTimestampedBinary = Path.Combine(AppContext.BaseDirectory, "TpmSim", "vcruntime140d.dll");
+
+        /// <summary>
+        ///     An unsigned binary.
+        /// </summary>
+        private static readonly string UnsignedBinary = Path.Combine(AppContext.BaseDirectory, "TpmSim", "Simulator.exe");
+
+        /// <summary>
+        ///     Assemblies shipped alongside the tests which are timestamped with the modern RFC 3161 format.
+        ///     Any of these exercises the RFC 3161 code path; the first usable one is chosen at runtime so a
+        ///     package update cannot silently remove coverage.
+        /// </summary>
+        private static readonly string[] Rfc3161TimestampedCandidates =
+        {
+            "Microsoft.Data.Sqlite.dll",
+            "Newtonsoft.Json.dll",
+            "Microsoft.CodeAnalysis.dll"
+        };
+
+        [ClassInitialize]
+        public static void ClassSetup(TestContext _)
+        {
+            Logger.Setup(false, true);
+            Strings.Setup();
+        }
+
+        #region IsTimeValid unit tests
+
         [TestMethod]
         public void IsTimeValid_SignedDuringCertValidity_ReturnsTrue()
         {
-            var sig = new Signature()
-            {
-                SigningCertificate = new SerializableCertificate(
-                    "thumbprint", "CN=Test", "key",
-                    new DateTime(2025, 12, 31), // NotAfter
-                    new DateTime(2020, 1, 1),   // NotBefore
-                    "CN=Issuer", "serial", "hash", "pkcs7"),
-                SigningTime = new DateTime(2023, 6, 15) // Signed within validity
-            };
+            var sig = MakeSignature(signingTime: new DateTime(2023, 6, 15),
+                                    notBefore: new DateTime(2020, 1, 1),
+                                    notAfter: new DateTime(2025, 12, 31));
             Assert.IsTrue(sig.IsTimeValid);
         }
 
         [TestMethod]
         public void IsTimeValid_SignedAfterCertExpiry_ReturnsFalse()
         {
-            var sig = new Signature()
-            {
-                SigningCertificate = new SerializableCertificate(
-                    "thumbprint", "CN=Test", "key",
-                    new DateTime(2022, 12, 31), // NotAfter
-                    new DateTime(2020, 1, 1),   // NotBefore
-                    "CN=Issuer", "serial", "hash", "pkcs7"),
-                SigningTime = new DateTime(2023, 6, 15) // Signed after expiry
-            };
+            var sig = MakeSignature(signingTime: new DateTime(2023, 6, 15),
+                                    notBefore: new DateTime(2020, 1, 1),
+                                    notAfter: new DateTime(2022, 12, 31));
             Assert.IsFalse(sig.IsTimeValid);
         }
 
         [TestMethod]
         public void IsTimeValid_SignedBeforeCertNotBefore_ReturnsFalse()
         {
-            var sig = new Signature()
-            {
-                SigningCertificate = new SerializableCertificate(
-                    "thumbprint", "CN=Test", "key",
-                    new DateTime(2025, 12, 31), // NotAfter
-                    new DateTime(2020, 1, 1),   // NotBefore
-                    "CN=Issuer", "serial", "hash", "pkcs7"),
-                SigningTime = new DateTime(2019, 6, 15) // Signed before NotBefore
-            };
+            var sig = MakeSignature(signingTime: new DateTime(2019, 6, 15),
+                                    notBefore: new DateTime(2020, 1, 1),
+                                    notAfter: new DateTime(2025, 12, 31));
             Assert.IsFalse(sig.IsTimeValid);
         }
 
         [TestMethod]
         public void IsTimeValid_NullSigningTime_ReturnsFalse()
         {
-            var sig = new Signature()
-            {
-                SigningCertificate = new SerializableCertificate(
-                    "thumbprint", "CN=Test", "key",
-                    new DateTime(2025, 12, 31),
-                    new DateTime(2020, 1, 1),
-                    "CN=Issuer", "serial", "hash", "pkcs7"),
-                SigningTime = null
-            };
+            var sig = MakeSignature(signingTime: null,
+                                    notBefore: new DateTime(2020, 1, 1),
+                                    notAfter: new DateTime(2025, 12, 31));
             Assert.IsFalse(sig.IsTimeValid);
         }
 
         [TestMethod]
         public void IsTimeValid_NullSigningCertificate_ReturnsFalse()
         {
-            var sig = new Signature()
-            {
-                SigningCertificate = null,
-                SigningTime = new DateTime(2023, 6, 15)
-            };
+            var sig = new Signature() { SigningCertificate = null, SigningTime = new DateTime(2023, 6, 15) };
             Assert.IsFalse(sig.IsTimeValid);
         }
 
@@ -85,15 +98,9 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Tests
         public void IsTimeValid_CertExpiredNow_ButSignedDuringValidity_ReturnsTrue()
         {
             // This is the key scenario: cert is currently expired, but was valid when signing occurred
-            var sig = new Signature()
-            {
-                SigningCertificate = new SerializableCertificate(
-                    "thumbprint", "CN=Test", "key",
-                    new DateTime(2020, 12, 31), // NotAfter - expired now
-                    new DateTime(2018, 1, 1),   // NotBefore
-                    "CN=Issuer", "serial", "hash", "pkcs7"),
-                SigningTime = new DateTime(2019, 6, 15) // Signed while cert was valid
-            };
+            var sig = MakeSignature(signingTime: new DateTime(2019, 6, 15),
+                                    notBefore: new DateTime(2018, 1, 1),
+                                    notAfter: new DateTime(2020, 12, 31));
             Assert.IsTrue(sig.IsTimeValid);
         }
 
@@ -101,15 +108,7 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Tests
         public void IsTimeValid_SignedExactlyAtNotBefore_ReturnsTrue()
         {
             var notBefore = new DateTime(2020, 1, 1);
-            var sig = new Signature()
-            {
-                SigningCertificate = new SerializableCertificate(
-                    "thumbprint", "CN=Test", "key",
-                    new DateTime(2025, 12, 31),
-                    notBefore,
-                    "CN=Issuer", "serial", "hash", "pkcs7"),
-                SigningTime = notBefore // Signed exactly at NotBefore boundary
-            };
+            var sig = MakeSignature(signingTime: notBefore, notBefore: notBefore, notAfter: new DateTime(2025, 12, 31));
             Assert.IsTrue(sig.IsTimeValid);
         }
 
@@ -117,67 +116,130 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Tests
         public void IsTimeValid_SignedExactlyAtNotAfter_ReturnsTrue()
         {
             var notAfter = new DateTime(2025, 12, 31);
-            var sig = new Signature()
-            {
-                SigningCertificate = new SerializableCertificate(
-                    "thumbprint", "CN=Test", "key",
-                    notAfter,
-                    new DateTime(2020, 1, 1),
-                    "CN=Issuer", "serial", "hash", "pkcs7"),
-                SigningTime = notAfter // Signed exactly at NotAfter boundary
-            };
+            var sig = MakeSignature(signingTime: notAfter, notBefore: new DateTime(2020, 1, 1), notAfter: notAfter);
             Assert.IsTrue(sig.IsTimeValid);
         }
 
         [TestMethod]
-        public void GetSignatureStatus_WithSignedPeFile_PopulatesSigningTime()
+        public void IsTimeValid_SameInstantExpressedInDifferentKinds_AgreesOnValidity()
         {
-            // vcruntime140d.dll is a signed Microsoft PE binary already in the repo
-            var path = Path.Combine(AppContext.BaseDirectory, "TpmSim", "vcruntime140d.dll");
-            if (!File.Exists(path))
-                Assert.Inconclusive("Test binary not found at: " + path);
+            var notBeforeUtc = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var notAfterUtc = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var signingTimeUtc = new DateTime(2020, 6, 1, 0, 0, 0, DateTimeKind.Utc);
 
-            using var stream = File.OpenRead(path);
-            var sig = WindowsFileSystemUtils.GetSignatureStatus(path, stream);
+            var allUtc = MakeSignature(signingTimeUtc, notBeforeUtc, notAfterUtc);
+            var allLocal = MakeSignature(signingTimeUtc.ToLocalTime(), notBeforeUtc.ToLocalTime(), notAfterUtc.ToLocalTime());
+            // Signing times are recovered as UTC while certificate validity comes back as local time,
+            // which is the combination produced by a real collection.
+            var mixed = MakeSignature(signingTimeUtc, notBeforeUtc.ToLocalTime(), notAfterUtc.ToLocalTime());
 
-            Assert.IsNotNull(sig, "Should parse a PE file's signature");
-            Assert.IsNotNull(sig.SigningTime, "Signed binary should have an extracted SigningTime");
+            Assert.IsTrue(allUtc.IsTimeValid);
+            Assert.AreEqual(allUtc.IsTimeValid, allLocal.IsTimeValid, "Validity must not depend on how the times are expressed");
+            Assert.AreEqual(allUtc.IsTimeValid, mixed.IsTimeValid, "Validity must not depend on how the times are expressed");
+        }
+
+        [TestMethod]
+        public void IsTimeValid_UtcSigningTimeAtLocalCertBoundary_ComparesInUtc()
+        {
+            var notBeforeLocal = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Local);
+            var notAfterLocal = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Local);
+
+            var atNotAfter = MakeSignature(notAfterLocal.ToUniversalTime(), notBeforeLocal, notAfterLocal);
+            Assert.IsTrue(atNotAfter.IsTimeValid, "Signing exactly at NotAfter is inside the validity period");
+
+            var atNotBefore = MakeSignature(notBeforeLocal.ToUniversalTime(), notBeforeLocal, notAfterLocal);
+            Assert.IsTrue(atNotBefore.IsTimeValid, "Signing exactly at NotBefore is inside the validity period");
+
+            var pastNotAfter = MakeSignature(notAfterLocal.ToUniversalTime().AddSeconds(1), notBeforeLocal, notAfterLocal);
+            Assert.IsFalse(pastNotAfter.IsTimeValid, "Signing one second after NotAfter is outside the validity period");
+
+            var beforeNotBefore = MakeSignature(notBeforeLocal.ToUniversalTime().AddSeconds(-1), notBeforeLocal, notAfterLocal);
+            Assert.IsFalse(beforeNotBefore.IsTimeValid, "Signing one second before NotBefore is outside the validity period");
+        }
+
+        #endregion
+
+        #region Signing time extraction against real binaries
+
+        [TestMethod]
+        public void GetSignatureStatus_LegacyCounterSignedBinary_PopulatesSigningTime()
+        {
+            var sig = GetSignatureOrInconclusive(LegacyTimestampedBinary);
+
             Assert.IsTrue(sig.IsAuthenticodeValid, "Known-signed binary should be authenticode valid");
-            // The signing time should be within a reasonable historical range
+            Assert.IsNotNull(sig.SigningTime, "Signed binary should have an extracted SigningTime");
+            Assert.AreEqual(DateTimeKind.Utc, sig.SigningTime.Value.Kind, "Signing times are reported in UTC");
             Assert.IsTrue(sig.SigningTime.Value > new DateTime(2000, 1, 1), "SigningTime should be a reasonable date");
             Assert.IsTrue(sig.SigningTime.Value < DateTime.UtcNow, "SigningTime should be in the past");
         }
 
         [TestMethod]
-        public void GetSignatureStatus_WithSignedPeFile_IsTimeValidReflectsSigningWindow()
+        public void GetSignatureStatus_LegacyCounterSignedBinary_IsTimeValidReflectsSigningWindow()
         {
-            var path = Path.Combine(AppContext.BaseDirectory, "TpmSim", "vcruntime140d.dll");
-            if (!File.Exists(path))
-                Assert.Inconclusive("Test binary not found at: " + path);
+            var sig = GetSignatureOrInconclusive(LegacyTimestampedBinary);
 
-            using var stream = File.OpenRead(path);
-            var sig = WindowsFileSystemUtils.GetSignatureStatus(path, stream);
-
-            Assert.IsNotNull(sig);
             Assert.IsNotNull(sig.SigningTime);
             Assert.IsNotNull(sig.SigningCertificate);
-            // The binary was signed while the certificate was valid
-            Assert.IsTrue(sig.SigningTime.Value >= sig.SigningCertificate.NotBefore,
-                $"SigningTime {sig.SigningTime} should be >= cert NotBefore {sig.SigningCertificate.NotBefore}");
-            Assert.IsTrue(sig.SigningTime.Value <= sig.SigningCertificate.NotAfter,
-                $"SigningTime {sig.SigningTime} should be <= cert NotAfter {sig.SigningCertificate.NotAfter}");
             Assert.IsTrue(sig.IsTimeValid, "A properly timestamped binary should have IsTimeValid = true");
+        }
+
+        /// <summary>
+        ///     Modern Authenticode signatures carry an RFC 3161 timestamp token instead of a PKCS#9
+        ///     countersignature, and the token's authoritative time is the genTime of its encapsulated
+        ///     TSTInfo rather than a signingTime attribute. Without support for that shape virtually every
+        ///     current Windows binary would report an unknown signing time.
+        /// </summary>
+        [TestMethod]
+        public void GetSignatureStatus_Rfc3161TimestampedBinary_PopulatesSigningTime()
+        {
+            var path = FindRfc3161TimestampedBinary();
+            if (path is null)
+            {
+                Assert.Inconclusive("No RFC 3161 timestamped binary was found next to the test assembly");
+                return;
+            }
+
+            Assert.AreEqual(0, CountPkcs9CounterSigners(path),
+                $"{Path.GetFileName(path)} must have no PKCS#9 countersignature, otherwise this test does not cover the RFC 3161 path");
+
+            var sig = GetSignatureOrInconclusive(path);
+
+            Assert.IsTrue(sig.IsAuthenticodeValid, "Known-signed binary should be authenticode valid");
+            Assert.IsNotNull(sig.SigningTime, "An RFC 3161 timestamped binary should have an extracted SigningTime");
+            Assert.AreEqual(DateTimeKind.Utc, sig.SigningTime.Value.Kind, "Signing times are reported in UTC");
+            Assert.IsTrue(sig.SigningTime.Value > new DateTime(2000, 1, 1), "SigningTime should be a reasonable date");
+            Assert.IsTrue(sig.SigningTime.Value < DateTime.UtcNow, "SigningTime should be in the past");
+        }
+
+        [TestMethod]
+        public void GetSignatureStatus_Rfc3161TimestampedBinary_IsTimeValidReflectsSigningWindow()
+        {
+            var path = FindRfc3161TimestampedBinary();
+            if (path is null)
+            {
+                Assert.Inconclusive("No RFC 3161 timestamped binary was found next to the test assembly");
+                return;
+            }
+
+            var sig = GetSignatureOrInconclusive(path);
+
+            Assert.IsNotNull(sig.SigningTime);
+            Assert.IsNotNull(sig.SigningCertificate);
+            Assert.IsTrue(sig.IsTimeValid,
+                $"Signed at {sig.SigningTime:u}, certificate valid {sig.SigningCertificate.NotBefore:u}..{sig.SigningCertificate.NotAfter:u}");
         }
 
         [TestMethod]
         public void GetSignatureStatus_WithUnsignedPeFile_HasNullSigningTime()
         {
-            var path = Path.Combine(AppContext.BaseDirectory, "TpmSim", "Simulator.exe");
-            if (!File.Exists(path))
-                Assert.Inconclusive("Test binary not found at: " + path);
+            if (!File.Exists(UnsignedBinary))
+            {
+                Assert.Inconclusive("Test binary not found at: " + UnsignedBinary);
+                return;
+            }
 
-            using var stream = File.OpenRead(path);
-            var sig = WindowsFileSystemUtils.GetSignatureStatus(path, stream);
+            using var stream = File.OpenRead(UnsignedBinary);
+            var sig = WindowsFileSystemUtils.GetSignatureStatus(UnsignedBinary, stream);
 
             // Unsigned PE should either return null signature or have null SigningTime
             if (sig != null)
@@ -186,5 +248,243 @@ namespace Microsoft.CST.AttackSurfaceAnalyzer.Tests
                 Assert.IsFalse(sig.IsTimeValid, "Unsigned binary should have IsTimeValid = false");
             }
         }
+
+        [TestMethod]
+        public void GetSignatureStatus_PathAndStreamOverloads_AgreeOnSigningTime()
+        {
+            var path = FindRfc3161TimestampedBinary() ?? LegacyTimestampedBinary;
+            if (!File.Exists(path))
+            {
+                Assert.Inconclusive("Test binary not found at: " + path);
+                return;
+            }
+
+            var fromPath = WindowsFileSystemUtils.GetSignatureStatus(path);
+            using var stream = File.OpenRead(path);
+            var fromStream = WindowsFileSystemUtils.GetSignatureStatus(path, stream);
+
+            Assert.IsNotNull(fromPath);
+            Assert.IsNotNull(fromStream);
+            Assert.AreEqual(fromPath.SigningTime, fromStream.SigningTime, "Both collection paths must report the same signing time");
+        }
+
+        #endregion
+
+        #region Analysis rule tests
+
+        [TestMethod]
+        public void AnalysisRules_SignedWithinValidity_IsNotFlagged()
+        {
+            var rules = AnalyzeFileWith(MakeSignature(signingTime: new DateTime(2019, 6, 15, 0, 0, 0, DateTimeKind.Utc),
+                                                      notBefore: new DateTime(2018, 1, 1),
+                                                      notAfter: new DateTime(2030, 12, 31)));
+
+            CollectionAssert.DoesNotContain(rules, OutsideValidityRule);
+            CollectionAssert.DoesNotContain(rules, UndeterminableTimeRule);
+        }
+
+        /// <summary>
+        ///     The regression this whole feature exists to prevent: a binary signed and timestamped while
+        ///     its certificate was valid must not be reported once that certificate expires.
+        /// </summary>
+        [TestMethod]
+        public void AnalysisRules_CertificateExpiredButSignedWhileValid_IsNotFlagged()
+        {
+            var rules = AnalyzeFileWith(MakeSignature(signingTime: new DateTime(2019, 6, 15, 0, 0, 0, DateTimeKind.Utc),
+                                                      notBefore: new DateTime(2018, 1, 1),
+                                                      notAfter: new DateTime(2020, 12, 31)));
+
+            CollectionAssert.DoesNotContain(rules, OutsideValidityRule);
+            CollectionAssert.DoesNotContain(rules, UndeterminableTimeRule);
+        }
+
+        [TestMethod]
+        public void AnalysisRules_SignedAfterCertificateExpiry_FlagsOutsideValidityOnly()
+        {
+            var rules = AnalyzeFileWith(MakeSignature(signingTime: new DateTime(2023, 6, 15, 0, 0, 0, DateTimeKind.Utc),
+                                                      notBefore: new DateTime(2018, 1, 1),
+                                                      notAfter: new DateTime(2020, 12, 31)));
+
+            CollectionAssert.Contains(rules, OutsideValidityRule);
+            CollectionAssert.DoesNotContain(rules, UndeterminableTimeRule);
+        }
+
+        [TestMethod]
+        public void AnalysisRules_SignedBeforeCertificateNotBefore_FlagsOutsideValidityOnly()
+        {
+            var rules = AnalyzeFileWith(MakeSignature(signingTime: new DateTime(2017, 6, 15, 0, 0, 0, DateTimeKind.Utc),
+                                                      notBefore: new DateTime(2018, 1, 1),
+                                                      notAfter: new DateTime(2020, 12, 31)));
+
+            CollectionAssert.Contains(rules, OutsideValidityRule);
+            CollectionAssert.DoesNotContain(rules, UndeterminableTimeRule);
+        }
+
+        [TestMethod]
+        public void AnalysisRules_UndeterminableSigningTime_FlagsInformationRuleOnly()
+        {
+            var rules = AnalyzeFileWith(MakeSignature(signingTime: null,
+                                                      notBefore: new DateTime(2018, 1, 1),
+                                                      notAfter: new DateTime(2020, 12, 31)));
+
+            CollectionAssert.Contains(rules, UndeterminableTimeRule);
+            CollectionAssert.DoesNotContain(rules, OutsideValidityRule);
+        }
+
+        [TestMethod]
+        public void AnalysisRules_UnsignedBinary_IsNotFlagged()
+        {
+            var rules = AnalyzeFileWith(MakeSignature(signingTime: null,
+                                                      notBefore: new DateTime(2018, 1, 1),
+                                                      notAfter: new DateTime(2020, 12, 31),
+                                                      isAuthenticodeValid: false));
+
+            CollectionAssert.DoesNotContain(rules, OutsideValidityRule);
+            CollectionAssert.DoesNotContain(rules, UndeterminableTimeRule);
+        }
+
+        [TestMethod]
+        public void AnalysisRules_TheTwoSigningTimeRulesHaveDistinctSeverities()
+        {
+            var rules = RuleFile.LoadEmbeddedFilters().Rules
+                .Where(x => x.Name == OutsideValidityRule || x.Name == UndeterminableTimeRule)
+                .OfType<AsaRule>()
+                .ToList();
+
+            Assert.AreEqual(4, rules.Count, "Both rules should be defined for FILE and FILEMONITOR");
+            Assert.IsTrue(rules.Where(x => x.Name == OutsideValidityRule).All(x => x.Flag == ANALYSIS_RESULT_TYPE.WARNING));
+            Assert.IsTrue(rules.Where(x => x.Name == UndeterminableTimeRule).All(x => x.Flag == ANALYSIS_RESULT_TYPE.INFORMATION));
+        }
+
+        /// <summary>
+        ///     Guards against the analysis regressing into flagging ordinary, correctly signed binaries.
+        /// </summary>
+        [TestMethod]
+        public void AnalysisRules_RealTimestampedBinaries_AreNotFlagged()
+        {
+            var paths = Rfc3161TimestampedCandidates
+                .Select(x => Path.Combine(AppContext.BaseDirectory, x))
+                .Append(LegacyTimestampedBinary)
+                .Where(File.Exists)
+                .ToList();
+
+            if (paths.Count == 0)
+            {
+                Assert.Inconclusive("No signed binaries were found next to the test assembly");
+                return;
+            }
+
+            foreach (var path in paths)
+            {
+                var sig = WindowsFileSystemUtils.GetSignatureStatus(path);
+                if (sig is null || !sig.IsAuthenticodeValid)
+                {
+                    continue;
+                }
+
+                var rules = AnalyzeFileWith(sig, path);
+                CollectionAssert.DoesNotContain(rules, OutsideValidityRule, $"{Path.GetFileName(path)} was signed at {sig.SigningTime:u}");
+                CollectionAssert.DoesNotContain(rules, UndeterminableTimeRule, $"{Path.GetFileName(path)} has no recoverable signing time");
+            }
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static Signature MakeSignature(DateTime? signingTime, DateTime notBefore, DateTime notAfter, bool isAuthenticodeValid = true)
+        {
+            return new Signature()
+            {
+                IsAuthenticodeValid = isAuthenticodeValid,
+                SigningTime = signingTime,
+                SigningCertificate = new SerializableCertificate(
+                    Thumbprint: "thumbprint",
+                    Subject: "CN=Test",
+                    PublicKey: "key",
+                    NotAfter: notAfter,
+                    NotBefore: notBefore,
+                    Issuer: "CN=Issuer",
+                    SerialNumber: "serial",
+                    CertHashString: "hash",
+                    Pkcs7: "pkcs7")
+            };
+        }
+
+        private static Signature GetSignatureOrInconclusive(string path)
+        {
+            if (!File.Exists(path))
+            {
+                Assert.Inconclusive("Test binary not found at: " + path);
+            }
+
+            using var stream = File.OpenRead(path);
+            var sig = WindowsFileSystemUtils.GetSignatureStatus(path, stream);
+            Assert.IsNotNull(sig, "Should parse a PE file's signature");
+            return sig;
+        }
+
+        private static List<string> AnalyzeFileWith(Signature signature, string path = @"C:\test\binary.dll")
+        {
+            var analyzer = new AsaAnalyzer();
+            var ruleFile = RuleFile.LoadEmbeddedFilters();
+            var fso = new FileSystemObject(path) { SignatureStatus = signature, IsExecutable = true };
+
+            return analyzer.Analyze(ruleFile.Rules, new CompareResult() { Compare = fso })
+                .Select(x => x.Name)
+                .ToList();
+        }
+
+        /// <summary>
+        ///     Returns the first assembly next to the test binary which is Authenticode signed with an RFC
+        ///     3161 timestamp and no legacy PKCS#9 countersignature, or null when none is available.
+        /// </summary>
+        private static string? FindRfc3161TimestampedBinary()
+        {
+            foreach (var candidate in Rfc3161TimestampedCandidates)
+            {
+                var path = Path.Combine(AppContext.BaseDirectory, candidate);
+                if (!File.Exists(path))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    if (CountPkcs9CounterSigners(path) == 0 && HasWinCertificate(path))
+                    {
+                        return path;
+                    }
+                }
+                catch (Exception)
+                {
+                    // Not usable as a fixture, try the next candidate
+                }
+            }
+
+            return null;
+        }
+
+        private static bool HasWinCertificate(string path)
+        {
+            using var stream = File.OpenRead(path);
+            return PeFile.IsPeFile(stream) && new PeFile(stream).WinCertificate is not null;
+        }
+
+        private static int CountPkcs9CounterSigners(string path)
+        {
+            using var stream = File.OpenRead(path);
+            var certData = new PeFile(stream).WinCertificate?.BCertificate.ToArray();
+            if (certData is null)
+            {
+                return 0;
+            }
+
+            var cms = new SignedCms();
+            cms.Decode(certData);
+            return cms.SignerInfos.Cast<SignerInfo>().Sum(x => x.CounterSignerInfos.Count);
+        }
+
+        #endregion
     }
 }

--- a/analyses.json
+++ b/analyses.json
@@ -1556,8 +1556,8 @@
       ]
     },
     {
-      "Name": "Binaries with unverified signature validity",
-      "Description": "These binaries have signatures where the signing time could not be verified as being within the certificate's validity period. The signing time may be outside the validity period or could not be determined.",
+      "Name": "Binaries signed outside certificate validity period",
+      "Description": "These binaries carry a signing time which falls outside the signing certificate's validity period, so the signature was not applied while the certificate was valid.",
       "Flag": "WARNING",
       "ResultType": "FILE",
       "ChangeTypes": [
@@ -1570,6 +1570,11 @@
           "Operation": "IsTrue"
         },
         {
+          "Field": "SignatureStatus.SigningTime",
+          "Operation": "IsNull",
+          "Invert": true
+        },
+        {
           "Field": "SignatureStatus.IsTimeValid",
           "Operation": "IsTrue",
           "Invert": true
@@ -1577,8 +1582,28 @@
       ]
     },
     {
-      "Name": "Binaries with unverified signature validity",
-      "Description": "These binaries have signatures where the signing time could not be verified as being within the certificate's validity period. The signing time may be outside the validity period or could not be determined.",
+      "Name": "Binaries with an undeterminable signing time",
+      "Description": "These binaries are signed but carry no recoverable signing time, so the signature cannot be confirmed as having been applied while the signing certificate was valid.",
+      "Flag": "INFORMATION",
+      "ResultType": "FILE",
+      "ChangeTypes": [
+        "MODIFIED",
+        "CREATED"
+      ],
+      "Clauses": [
+        {
+          "Field": "SignatureStatus.IsAuthenticodeValid",
+          "Operation": "IsTrue"
+        },
+        {
+          "Field": "SignatureStatus.SigningTime",
+          "Operation": "IsNull"
+        }
+      ]
+    },
+    {
+      "Name": "Binaries signed outside certificate validity period",
+      "Description": "These binaries carry a signing time which falls outside the signing certificate's validity period, so the signature was not applied while the certificate was valid.",
       "Flag": "WARNING",
       "ResultType": "FILEMONITOR",
       "ChangeTypes": [
@@ -1591,9 +1616,34 @@
           "Operation": "IsTrue"
         },
         {
+          "Field": "FileSystemObject.SignatureStatus.SigningTime",
+          "Operation": "IsNull",
+          "Invert": true
+        },
+        {
           "Field": "FileSystemObject.SignatureStatus.IsTimeValid",
           "Operation": "IsTrue",
           "Invert": true
+        }
+      ]
+    },
+    {
+      "Name": "Binaries with an undeterminable signing time",
+      "Description": "These binaries are signed but carry no recoverable signing time, so the signature cannot be confirmed as having been applied while the signing certificate was valid.",
+      "Flag": "INFORMATION",
+      "ResultType": "FILEMONITOR",
+      "ChangeTypes": [
+        "MODIFIED",
+        "CREATED"
+      ],
+      "Clauses": [
+        {
+          "Field": "FileSystemObject.SignatureStatus.IsAuthenticodeValid",
+          "Operation": "IsTrue"
+        },
+        {
+          "Field": "FileSystemObject.SignatureStatus.SigningTime",
+          "Operation": "IsNull"
         }
       ]
     },


### PR DESCRIPTION
## Why

PR #763 reworked binary signature expiry detection to compare the *signing time* against the certificate's validity period, rather than comparing "now" against `NotAfter`. That is the correct model: a binary that was properly signed and timestamped should stay valid after its signing certificate expires.

The intent was right, but the implementation never actually recovered a signing time for modern binaries, so the new check inverted into a false-positive generator. PR #763 could not be tested on Windows at the time it was written. This PR fixes it, and adds the test coverage that would have caught it.

## What was broken

**Signing time was never extracted for modern Authenticode signatures.** Microsoft's Authenticode RFC 3161 timestamps are carried in the unsigned attribute `1.3.6.1.4.1.311.3.3.1` (`szOID_RFC3161_counterSign`), not the standard `1.2.840.113549.1.9.16.2.14` that was being checked. Those tokens also carry no PKCS#9 `signingTime` attribute at all; the authoritative value is the `genTime` of the encapsulated `TSTInfo`. Only legacy PKCS#9 countersigned binaries were handled, so `SigningTime` came back null for nearly every signed binary. Because `IsTimeValid` returns false when the signing time is unknown, each of those binaries was reported as a warning.

Measured over a 505 file sweep of System32, dotnet, and PowerShell 7: signing times were recovered for only 2 of 323 authenticode-valid files, and the change produced **278 net new false positives**.

**`IsTimeValid` compared mixed time bases.** Signing times are recovered as `Kind=Utc`, while certificate validity comes back from `X509Certificate2` as `Kind=Local`. The comparison silently shifted by the machine's UTC offset, so results varied by timezone.

**The tests masked both bugs.** All 11 tests added by #763 used `vcruntime140d.dll`, the single legacy-countersigned fixture in the repo, which happens to be the one code path that worked. That is why the suite was green while the feature was broken.

## Approach

`WindowsFileSystemUtils` now matches both timestamp OIDs and parses `TSTInfo.genTime` out of the RFC 3161 token using `AsnReader`, falling back to a PKCS#9 time on the token signer if a TSA does supply one. The legacy countersigner path is preserved and still tried first, so nothing regresses for older binaries.

`Signature.IsTimeValid` normalizes all three operands to UTC before comparing.

`analyses.json` splits the single ambiguous rule into two rules with distinct severities, since the two situations it conflated are very different in practice:

- **Binaries signed outside certificate validity period** stays `WARNING`. This is genuinely suspicious.
- **Binaries with an undeterminable signing time** becomes `INFORMATION`. This is expected for catalog-signed binaries and unusual signers, and is not by itself an integrity problem.

Both variants are defined for `FILE` and `FILEMONITOR`. The discriminator is a `SigningTime IsNull` clause (inverted for the warning rule), which was verified to route correctly through OAT.

`SignatureTests` grows from 11 to 24 tests, covering RFC 3161 timestamped binaries, `DateTime.Kind` normalization, and rule routing through the real analyzer against the embedded rule set. The RFC 3161 test asserts that its fixture has zero PKCS#9 countersigners, so it cannot silently stop covering the new path if the fixture is ever swapped.

## Validation

All run on Windows.

| Check | Result |
| --- | --- |
| Build, net8.0 and net9.0 | 0 errors |
| `SignatureTests` | 24/24 pass |
| Full CI filter `TestCategory=PipelineSafeTests` | 77/77 on net8.0, 77/77 on net9.0 |
| Negative control: fixes stashed, new tests against old lib | 7 of 24 fail, as expected |
| 505 file sweep, signing times recovered | 2/323 -> 323/323 |
| 505 file sweep, false positives | 278 -> 0 |
| `EnumerateRuleIssues` on embedded rules | 0 issues |
| End-to-end `asa collect` + `export-collect` | `SigningTime` round-trips through SQLite and JSON export |

End-to-end spot check: `Microsoft.Data.Sqlite.dll` (certificate expired 2026-06-17, signed 2025-09-26) and `vcruntime140d.dll` (certificate expired 2020, signed 2019) both now resolve to `IsTimeValid=True` with zero rules flagged, which is exactly the scenario #763 set out to fix. Unsigned binaries are still correctly caught by the pre-existing "Unsigned binaries" rule.

## Notes for reviewers

Runs collected before this change have no `SigningTime` stored, so comparing a new run against an older baseline will match every previously-collected signed binary against the "undeterminable signing time" rule. This is inherent to adding a new collected field. The severity split keeps that noise at `INFORMATION` instead of `WARNING`, which was part of the motivation for splitting the rules.

`Tests/TestData/ExportTests/TestGenerateSarifLog/rules.json` still contains the original pre-#763 rule name. It is a frozen SARIF input snapshot that is deliberately decoupled from `analyses.json`, so it is intentionally left unchanged.

The ASN.1 reader uses BER rather than DER and deliberately does not call `ThrowIfNotEmpty`, because the trailing `TSTInfo` fields after `genTime` are optional.